### PR TITLE
Initial content pass across all sections

### DIFF
--- a/.claude/audit/source-state.json
+++ b/.claude/audit/source-state.json
@@ -1,6 +1,2131 @@
 {
   "version": 1,
-  "captured_at": null,
-  "gaia_commit": null,
-  "items": []
+  "captured_at": "2026-05-09T00:00:00Z",
+  "gaia_commit": "c08efa5ba1a9b6b55515c97741ef1a0749163f77",
+  "items": [
+    {
+      "kind": "agent",
+      "path": ".claude/agents/code-review-audit.md",
+      "name": "code-review-audit",
+      "description": "Comprehensive code review, security audit, performance analysis, and architectural assessment. Goes beyond linting and type-checking to identify vulnerabilities, bottlenecks, code smells, anti-patterns, and refactoring opportunities. Mandatory before PR merge.",
+      "audience": "adopter",
+      "content_hash": "2c654065221923ad503f41f7dfe24742b6fa2788f55a23759b718337e0ffc4ee",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/index.ts",
+      "name": "_internal-fetch-coaching",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "6e1e2f5f468a7722f268850cafe5f5e3f29f67d6fb3b5a6595863f1a53d35345",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/init/index.ts",
+      "name": "gaia init configure-i18n",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5f143760e7658d86f15f00e2a25b1a35636dd8757bd29619976b789acea039bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/init/index.ts",
+      "name": "gaia init finalize",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5f143760e7658d86f15f00e2a25b1a35636dd8757bd29619976b789acea039bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/init/index.ts",
+      "name": "gaia init rename",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5f143760e7658d86f15f00e2a25b1a35636dd8757bd29619976b789acea039bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/init/index.ts",
+      "name": "gaia init resume",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5f143760e7658d86f15f00e2a25b1a35636dd8757bd29619976b789acea039bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/init/index.ts",
+      "name": "gaia init strip-branding",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5f143760e7658d86f15f00e2a25b1a35636dd8757bd29619976b789acea039bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/init/index.ts",
+      "name": "gaia init wire-statusline",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5f143760e7658d86f15f00e2a25b1a35636dd8757bd29619976b789acea039bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship _internal-assert-memory-rules",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship _internal-provision-dirs",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship _internal-write-config",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship analytics disable",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship analytics dry-run",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship analytics enable",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship disable",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship enable",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship purge",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/mentorship/index.ts",
+      "name": "gaia mentorship status",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "9282671c084574dd1cf7c39f92bd04a3e1d091cc1b44077895eab30f47a60de4",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release bump",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release changelog",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release commit-and-tag",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release manifest",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release preflight",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release runtime-deps",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release scrub",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/release/index.ts",
+      "name": "gaia release scrub-wiki",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "3fde38adc09b341916baea8ff8a4df1cbd4419295378a7b6c185545425f40db8",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/scaffold/index.ts",
+      "name": "gaia scaffold component",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "13534bd4dbe632c85c6953004115029cb5c6d1201b8c86b34de1681f51bb25eb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/scaffold/index.ts",
+      "name": "gaia scaffold hook",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "13534bd4dbe632c85c6953004115029cb5c6d1201b8c86b34de1681f51bb25eb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/scaffold/index.ts",
+      "name": "gaia scaffold route",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "13534bd4dbe632c85c6953004115029cb5c6d1201b8c86b34de1681f51bb25eb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/scaffold/index.ts",
+      "name": "gaia scaffold service",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "13534bd4dbe632c85c6953004115029cb5c6d1201b8c86b34de1681f51bb25eb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/setup/index.ts",
+      "name": "gaia setup finalize",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5c1c4a691aa4e902e38215ada43493b203e0809e2360a25ee90f751090787559",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/setup/index.ts",
+      "name": "gaia setup link-worktree",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5c1c4a691aa4e902e38215ada43493b203e0809e2360a25ee90f751090787559",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/setup/index.ts",
+      "name": "gaia setup mark-step",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5c1c4a691aa4e902e38215ada43493b203e0809e2360a25ee90f751090787559",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/setup/index.ts",
+      "name": "gaia setup status",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "5c1c4a691aa4e902e38215ada43493b203e0809e2360a25ee90f751090787559",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/telemetry/index.ts",
+      "name": "gaia telemetry compute-profile",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "87e07a573a092a4b43f05e1624a7ded2baa1d57993ca79baa97cf8c16e523207",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/telemetry/index.ts",
+      "name": "gaia telemetry emit",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "87e07a573a092a4b43f05e1624a7ded2baa1d57993ca79baa97cf8c16e523207",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/telemetry/index.ts",
+      "name": "gaia telemetry parse-stdin",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "87e07a573a092a4b43f05e1624a7ded2baa1d57993ca79baa97cf8c16e523207",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/update/index.ts",
+      "name": "gaia update merge",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "0c36fb07642d4fc76c5657b659cd53dd2375766b4e2508bed6b7a8f0181a1205",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki commit-classify",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki dead-paths",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki log-prepend",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki near-collisions",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki orphans",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki page-index",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki state",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki state-bump",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki state-init",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "cli-subcommand",
+      "path": ".gaia/cli/src/wiki/index.ts",
+      "name": "gaia wiki sync land",
+      "description": null,
+      "audience": "adopter",
+      "content_hash": "95e6f47bffac27eabc4fcb1ba90e99686b044aa3968a0c50f7da90b4333d9514",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "command",
+      "path": ".claude/commands/gaia-init.md",
+      "name": "gaia-init",
+      "description": "Initialize a new project from the GAIA React template \u2014 renames, strips GAIA branding, configures i18n, installs Claude skills/plugins.",
+      "audience": "adopter",
+      "content_hash": "782cda410656c0edca408d4d6757877c07dc8a3b4f4fdb0f45693130aaf6286d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "command",
+      "path": ".claude/commands/gaia-release.md",
+      "name": "gaia-release",
+      "description": "Cut a new GAIA release \u2014 bump version, graduate CHANGELOG, regenerate manifest, open release PR, then tag on merge. Maintainer-only.",
+      "audience": "contributor",
+      "content_hash": "dff68ad2172fe7434ab248aa89067176e94375422f4e691a542bc263bd2ef5c6",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "command",
+      "path": ".claude/commands/health-audit.md",
+      "name": "health-audit",
+      "description": "Maintainer-only autonomous health audit + auto-heal loop. Runs N=3 fresh-team audit-fix-audit cycles with circuit breakers, reports A+/A/A\u2212 verdict or escalates.",
+      "audience": "contributor",
+      "content_hash": "94f6d1544083df20378d70c56082ba0352ec4239d71063ce93344eb89c3da881",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "command",
+      "path": ".claude/commands/setup-gaia.md",
+      "name": "setup-gaia",
+      "description": "One-shot per-machine setup for a cloned GAIA project. Installs tools, plugins, spec-kit; bootstraps .env; opts into mentorship. Idempotent \u2014 safe to re-run.",
+      "audience": "adopter",
+      "content_hash": "b65a46ee5169428febc4b21125f19d9991dbd4818d0fd7c8f1c729778665527f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/audit-stamp-trailer.sh",
+      "name": "audit-stamp-trailer.sh",
+      "description": "audit-stamp-trailer.sh \u2014 write the GAIA-Audit commit trailer on HEAD.",
+      "audience": "adopter",
+      "content_hash": "c7ef9dac85a7ca69d5d7d7ddaa5b94a58ef70b0157e227c257e24142c8472517",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-bare-test.sh",
+      "name": "block-bare-test.sh",
+      "description": "Block bare `pnpm test` / `npm test` (and `run test` variants) without `--run` \u2014",
+      "audience": "adopter",
+      "content_hash": "cf00fa92c5fb256a093db5014af13cb0723192b46d7afc14b861fb4a2b2e29d6",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-env-write.sh",
+      "name": "block-env-write.sh",
+      "description": "PreToolUse Edit/Write hook: deny writes targeting `.env` files.",
+      "audience": "adopter",
+      "content_hash": "7c092ca4ccf4a025537c4e2e296422cea207445af9f9d8e05a0a15c4e10910fc",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-eslint-config-edit.sh",
+      "name": "block-eslint-config-edit.sh",
+      "description": "Block modifications to eslint.config.{js,cjs,mjs,ts} at any path.",
+      "audience": "adopter",
+      "content_hash": "a20cb9ff28f8651b2c0a7448c0b56e20b03d1e816149433f728dbfacccd6fbc0",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-lockfile-edit.sh",
+      "name": "block-lockfile-edit.sh",
+      "description": "PreToolUse Edit/Write hook: deny direct edits to package lockfiles.",
+      "audience": "adopter",
+      "content_hash": "c15be2bba7c058e0917a6c47cba553f09d5788b40a4f55f6c19bd46875ffbc73",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-main-destructive-git.sh",
+      "name": "block-main-destructive-git.sh",
+      "description": "PreToolUse Bash hook: block commits to main/master and force-push to main/master.",
+      "audience": "adopter",
+      "content_hash": "87461a3cb35d906498ee6d6b732fa2147a376514d5148c94445ea0700b152a5a",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-rm-rf.sh",
+      "name": "block-rm-rf.sh",
+      "description": "PreToolUse Bash hook: deny dangerous `rm -rf` invocations.",
+      "audience": "adopter",
+      "content_hash": "f9f366a66905dba9f9a90465474f31302356a8146a7ef39af1e7bce3a71f8164",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-secrets-write.sh",
+      "name": "block-secrets-write.sh",
+      "description": "PreToolUse Edit/Write hook: deny writes that contain obvious secrets.",
+      "audience": "adopter",
+      "content_hash": "52800bf52a0c92dcf707846ad42ce85c95f3f87f1697e59aba0e39658089d8de",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/block-vitest-globals-tsconfig.sh",
+      "name": "block-vitest-globals-tsconfig.sh",
+      "description": "Block adding vitest/globals to tsconfig.json",
+      "audience": "adopter",
+      "content_hash": "b554cf5a5e5fe961f74b7da0007a9ec38f508f5dcc9bdf5f904fc3cc79b03bbd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/check-i18n-strings.sh",
+      "name": "check-i18n-strings.sh",
+      "description": "Advisory check: warn about potential hardcoded strings in JSX.",
+      "audience": "adopter",
+      "content_hash": "fae62d18f5ec6ad55c9be999bfbd321b32e2d9c9601c8dc658690598fcdd6574",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/check-story-exists.sh",
+      "name": "check-story-exists.sh",
+      "description": "Advisory check: remind to add Storybook story for new components",
+      "audience": "adopter",
+      "content_hash": "aafaf02b560d8095bc781505a508fdbb32beb79c27064abed4147864d3d7ed58",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/intercept-init.sh",
+      "name": "intercept-init.sh",
+      "description": "Redirect the built-in /init command to /gaia-init on this template.",
+      "audience": "adopter",
+      "content_hash": "bee4266d7a06e3b1e7a0f965ef7df4faf40fd89e26a9160052e93e161c6e608e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/pr-merge-audit-check.sh",
+      "name": "pr-merge-audit-check.sh",
+      "description": "PreToolUse Bash hook: BLOCK `gh pr merge` until a code-review-audit marker",
+      "audience": "adopter",
+      "content_hash": "e3930156e7ece9ae8d2e98bff74079a9a0f56fe219dcd567f6871baf68259e00",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/telemetry-task-postuse.sh",
+      "name": "telemetry-task-postuse.sh",
+      "description": "PostToolUse Task hook: extract structured-trailer events from the agent's",
+      "audience": "adopter",
+      "content_hash": "0a8258ad361b7d3f6a3eaffe8ca2ab906ce4c423f9d9f08a45f2c14da8c59377",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/wiki-commit-nudge.sh",
+      "name": "wiki-commit-nudge.sh",
+      "description": "PostToolUse hook on Bash matching `git commit`. Inject a one-line nudge",
+      "audience": "adopter",
+      "content_hash": "6e20bdeadf0ec91fb8f8cd9919d63931772ada102319b0f6326efe42ecf8d66b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/wiki-drift-check.sh",
+      "name": "wiki-drift-check.sh",
+      "description": "UserPromptSubmit hook: detect drift between wiki/.state.json and HEAD,",
+      "audience": "adopter",
+      "content_hash": "b690ae0290e3b01cffa1d1ff1c8f67ab56fe9ab687ffe4de1ca8d0159675b237",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/wiki-session-start.sh",
+      "name": "wiki-session-start.sh",
+      "description": "GAIA-owned wiki hook. Upstream contract: claude-obsidian/hooks/hooks.json::SessionStart",
+      "audience": "adopter",
+      "content_hash": "2825c894b44a75b332f35de2523e193b577289c326938adc7ab0d0f86ead648e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/wiki-session-stop.sh",
+      "name": "wiki-session-stop.sh",
+      "description": "GAIA-owned Stop hook (merged: session-stop + safety-net).",
+      "audience": "adopter",
+      "content_hash": "8e1ce59d612dbc06352e9574f2b48876251821e2de2a73cfa85695e1ef9d280c",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "hook",
+      "path": ".claude/hooks/wiki-squash-autocommits.sh",
+      "name": "wiki-squash-autocommits.sh",
+      "description": "GAIA-owned wiki hook. Upstream contract: claude-obsidian/hooks/hooks.json::PostToolUse (auto-commit per Write|Edit)",
+      "audience": "adopter",
+      "content_hash": "1aca0d807e7023d637b17c3db03b6c08789c24fdb96328af4260aa1a315cf8bb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/accessibility.md",
+      "name": "accessibility",
+      "description": "Accessibility",
+      "audience": "adopter",
+      "content_hash": "89f5e20e5c451b73e3af8c5979da467e022e26c7744383a29972a7e1ce1d382b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/api-service.md",
+      "name": "api-service",
+      "description": "API Service Pattern",
+      "audience": "adopter",
+      "content_hash": "e89cd84388867108950f2b17a8c9bf758994eaea2454678d89eb29eb746857a7",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/code-search.md",
+      "name": "code-search",
+      "description": "Code Search",
+      "audience": "adopter",
+      "content_hash": "536ec7192095816e38a854e87998a8572d236fa58d4b7f1adfc4a9a7d8efea0e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/coding-guidelines.md",
+      "name": "coding-guidelines",
+      "description": "Coding Guidelines",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/i18n.md",
+      "name": "i18n",
+      "description": "Internationalization (i18n)",
+      "audience": "adopter",
+      "content_hash": "ed131d2ef25cd93d7db1dff55d17ff23650a0b2605a81aa4f038709b7884531f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/instruction-files.md",
+      "name": "instruction-files",
+      "description": "Template-Distributed File Paths",
+      "audience": "adopter",
+      "content_hash": "9a5b4efe4fde62eee2c6ca96de66b398fc623c25b5d1b7951fb75177bd5d8ccc",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/knip.md",
+      "name": "knip",
+      "description": "Knip \u2014 Dead Code Detection",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/playwright.md",
+      "name": "playwright",
+      "description": "Playwright E2E Conventions",
+      "audience": "adopter",
+      "content_hash": "076f10294a0619ef4a061b25c00772def37d4556f55f5eb5e231d7267b3d5f60",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/quality-gate.md",
+      "name": "quality-gate",
+      "description": "Quality Gate",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/routes.md",
+      "name": "routes",
+      "description": "Route & Page Conventions",
+      "audience": "adopter",
+      "content_hash": "3bad5675aa7c207dffcbe4215b052f1267c2b840fdc867de095abba21bed3fbf",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/shell-cwd.md",
+      "name": "shell-cwd",
+      "description": "Shell CWD",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/state-pattern.md",
+      "name": "state-pattern",
+      "description": "State Pattern",
+      "audience": "adopter",
+      "content_hash": "4d0dd9b541f88c4cd165610bc44dffe90129d24b14ba6a54b8bb9472d796ce32",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/storybook.md",
+      "name": "storybook",
+      "description": "Storybook Conventions",
+      "audience": "adopter",
+      "content_hash": "73fb760cdf4209d65712374da1e71fe4143a1ae85288ea53ede9550c80278601",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/tailwind.md",
+      "name": "tailwind",
+      "description": "Tailwind Conventions",
+      "audience": "adopter",
+      "content_hash": "d86ab326bf4dea4807f01db0844485414baa23d9544cd801dd4798b924867763",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "rule",
+      "path": ".claude/rules/wiki-style.md",
+      "name": "wiki-style",
+      "description": "Wiki & Comment Style",
+      "audience": "adopter",
+      "content_hash": "bf54b6efbc32509c8e7d4309aad61a3eeb4c4c73df89cc59f24432f414f70f6b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/eslint-fixes/SKILL.md",
+      "name": "eslint-fixes",
+      "description": "Resolve specific ESLint errors and warnings that appear in this project. Use when fixing lint failures, ESLint reported issues, or autofix conflicts (e.g. no-void, canonical/export-specifier-newline vs prettier, no-shadow trailing underscores, sonarjs/deprecation, you-dont-need-lodash-underscore, testing-library/prefer-screen-queries, testing-library/await-async-events, jest-dom/prefer-*).",
+      "audience": "adopter",
+      "content_hash": "83d6f2e23cf1090676385c81a419dddc875faa183c8ec80ab5ab8d209b53b134",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/gaia/SKILL.md",
+      "name": "gaia",
+      "description": "GAIA workflow router. Dispatches to the user-invoked GAIA workflows - plan (task orchestration), spec (Socratic SPEC artifact), handoff (session handoff doc), pickup (resume from handoff), audit (knowledge audit), forensics (bug report bridge), wiki (sync/consolidate/lint chain). Trigger on `/gaia <subcommand>` or natural-language asks like \"kick off a plan\", \"write a handoff\", \"pick up where we left off\", \"audit the knowledge stores\", \"sync the wiki\".",
+      "audience": "adopter",
+      "content_hash": "e516fe6be42e43eaf4af430f5e8a7c23f8f3a74616775f74d4b7eb1ac5f0291d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/new-component/SKILL.md",
+      "name": "new-component",
+      "description": "Scaffold a new React component with optional Storybook story and Vitest test files. Use this skill whenever the user asks to \"create a component\", \"make a button\", \"scaffold a card\", \"add a new component\", or asks for a new file under `app/components/` following the project's component pattern (PascalCase folder, index.tsx, tests/).",
+      "audience": "adopter",
+      "content_hash": "a25ce53accf439464122f1cc63e174eada33c07183b6a4ef4ae9df3fdf4d30c9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/new-hook/SKILL.md",
+      "name": "new-hook",
+      "description": "Scaffold a new custom React hook with a Vitest test file. Use this skill whenever the user asks to \"create a hook\", \"make a useFoo hook\", \"scaffold a custom React hook\", \"add a hook under app/hooks\", or describes a piece of reusable React state/effect logic that warrants extraction into a named `use*` hook.",
+      "audience": "adopter",
+      "content_hash": "7982468af5d92db8cff68b8652006196feb2b6375e177010080e2f3af0cc3972",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/new-route/SKILL.md",
+      "name": "new-route",
+      "description": "Scaffold a new route with its page component, test, story, and optional i18n keys. Use this skill whenever the user asks to \"create a route\", \"add a new page\", \"scaffold /dashboard\", \"wire up a new route under _public+ or _session+\", or anything that implies adding a file under `app/routes/` with a matching `app/pages/{Group}/{PageName}/` folder.",
+      "audience": "adopter",
+      "content_hash": "6684cbbf9ae3271902bca2f06cd2853b568c45d47c01265ffb5f0df0802f424a",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/new-service/SKILL.md",
+      "name": "new-service",
+      "description": "Scaffold a new API service with request functions, Zod schemas, URL constants, and optional MSW mock handlers. Use this skill whenever the user asks to \"add a service\", \"create the projects API\", \"scaffold a new GAIA service\", \"wire up CRUD for users\", or anything implying a new folder under `app/services/gaia/{name}/` with parsers/types/requests + matching `test/mocks/{name}/` collections.",
+      "audience": "adopter",
+      "content_hash": "f70b515a9f2daa361b2bd5e1231f81a7f2a573a9b675c283d67c9c31da2d659c",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/playwright-cli/SKILL.md",
+      "name": "playwright-cli",
+      "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.",
+      "audience": "adopter",
+      "content_hash": "ad14eca4bd0d8b01b0257e77b1f2226271cc5098616da66f296670672616f6f8",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/react-code/SKILL.md",
+      "name": "react-code",
+      "description": "Patterns and conventions for writing and editing React code, including components and hooks. Use this skill whenever writing or reviewing React components, hooks (useEffect, useCallback, useState), event handlers, or component extraction decisions. Also trigger when debugging stale closures, infinite re-renders, or unnecessary re-renders caused by memoization issues.",
+      "audience": "adopter",
+      "content_hash": "fa1c1984ef2074953f1b080c8494ba585fb26f75464707eb12f12aea51e85904",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/skeleton-loaders/SKILL.md",
+      "name": "skeleton-loaders",
+      "description": "For building skeleton loading states that are pixel-perfect matches of real content. Use this skill whenever adding loading states to components, building skeletons for async data, handling pending loader states in route transitions, or implementing the shimmer animation pattern. Also trigger when the user asks about preventing layout shift during data fetching.",
+      "audience": "adopter",
+      "content_hash": "c34f3838166a2838526a7e4865468c81c34a232d40a7161b5a6e4b45d6eb7ed3",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/tailwind/SKILL.md",
+      "name": "tailwind",
+      "description": "Patterns and conventions for all Tailwind styling. Use this skill whenever writing Tailwind class names, combining conditional classes, building component variants, or choosing between twJoin and twMerge. Also trigger when the user asks about custom values, defining @theme tokens or CSS variables, naming color/spacing tokens, rem vs px, responsive breakpoints, or avoiding template literal class strings.",
+      "audience": "adopter",
+      "content_hash": "63c2f4378b05b08f70d16425204062b36a725ca4fb24ae6a6c1151944783f7ce",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/tdd/SKILL.md",
+      "name": "tdd",
+      "description": "Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions \"red-green-refactor\", wants integration tests, or asks for test-first development.",
+      "audience": "adopter",
+      "content_hash": "82d0b02600f97f8666bad7abfeec60beb25da61dc855cb882b330b917400094f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/typescript/SKILL.md",
+      "name": "typescript",
+      "description": "Patterns and conventions for all TypeScript code. Use this skill whenever writing or reviewing TypeScript \u2014 naming identifiers, typing exports, choosing between type and interface, using Zod schemas, structuring function parameters, or enforcing code patterns like avoiding switch statements and enums.",
+      "audience": "adopter",
+      "content_hash": "b393f5bf5c7b8225adcee6c4fccd22851ff127402138621f9a112681b90a18cf",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/update-deps/SKILL.md",
+      "name": "update-deps",
+      "description": "Autonomous Dependabot - auto-discover outdated packages, audit overrides, apply migrations for major bumps, resolve conflicts, run quality gate. Trigger when the user clicks the statusline `Run /update-deps` indicator or asks \"update dependencies\", \"bump deps\", \"run dependabot\".",
+      "audience": "adopter",
+      "content_hash": "f727cf7a3f625af33f10ce92ed723b23c926daf43eae0ea27da8ac9098792945",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "skill",
+      "path": ".claude/skills/update-gaia/SKILL.md",
+      "name": "update-gaia",
+      "description": "Pull the latest GAIA release into this project without clobbering customizations. Three-way merge per file using .gaia/manifest.json classes. Trigger when the user clicks the statusline `Run /update-gaia` indicator or asks \"update GAIA\", \"pull the latest GAIA\", \"apply the new GAIA release\".",
+      "audience": "adopter",
+      "content_hash": "ee8ca841bf8941b2bf5a3f349d749dbba49c496d58bbd97e0e2399b397f49f65",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/constitution-check.md",
+      "name": "speckit.gaia.constitution-check",
+      "description": "Verify .specify/memory/constitution.md has no placeholder text before /speckit.specify runs.",
+      "audience": "adopter",
+      "content_hash": "c27e449ca22d255de77775ac82111e0c7d51e85852ea6f91a0656f9017ecca01",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/lint.md",
+      "name": "speckit.gaia.lint",
+      "description": "Immutability lint over a saved SPEC artifact: frontmatter, frozen UAT-NNN ids, no placeholders.",
+      "audience": "adopter",
+      "content_hash": "591535fc4bbb75d7ca462861a097e38ff1fd023025703128fa3c5332d95166d1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/self-review.md",
+      "name": "speckit.gaia.self-review",
+      "description": "Pre-gate-2 self-review pass; surfaces drift, ambiguity, and pending clarifications before save.",
+      "audience": "adopter",
+      "content_hash": "4b2e53da05557ec529af7d86b6b9ebd78d25c728094e218e21284ccacfb2bad9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/spec.md",
+      "name": "speckit.gaia.spec",
+      "description": "GAIA Socratic discovery wrapper around /speckit.specify and /speckit.clarify.",
+      "audience": "adopter",
+      "content_hash": "570a6bbca95c88674405a54937229e7754009032415888d0c83311238c7b089f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/spec-close.md",
+      "name": "speckit.gaia.spec-close",
+      "description": "Close a SPEC after implementation+merge: optional drain of deferred wiki-promote, then archive/delete/keep prompt for the local SPEC artifact.",
+      "audience": "adopter",
+      "content_hash": "215a96ee13baa8946118f9016f003acb390f9b14bd4a59de6735d711a19714a1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/uat-write.md",
+      "name": "speckit.gaia.uat-write",
+      "description": "before_implement hook: render PO-authored UATs into Playwright e2e specs at .playwright/e2e/spec-NNN/.",
+      "audience": "adopter",
+      "content_hash": "7ad11049e522ffdcaa34edbd3378603b92304e5d4662cbfa46c43cba077db09f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "spec-kit-cmd",
+      "path": ".specify/extensions/gaia/commands/wiki-promote.md",
+      "name": "speckit.gaia.wiki-promote",
+      "description": "Promote merged SPEC content into the GAIA wiki.",
+      "audience": "adopter",
+      "content_hash": "a49b11dbc4445930c0e93411578d765076ecd079861507779bdfb616ce9533bb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/audit.md",
+      "name": "/gaia audit",
+      "description": "/gaia audit",
+      "audience": "adopter",
+      "content_hash": "95f9b65aeb85c7c9813eefdab2b924a9072a96c637e8fcc93d84c25b656f09ab",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/forensics.md",
+      "name": "/gaia forensics",
+      "description": "/gaia forensics",
+      "audience": "adopter",
+      "content_hash": "44e08a25ef3840d6b23160ef10043b6f0379e4a2f0e5de958f20d07fc9926aaa",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/handoff.md",
+      "name": "/gaia handoff",
+      "description": "/gaia handoff",
+      "audience": "adopter",
+      "content_hash": "61c4a17d330cfa3e6bd3ac13af3608907705ce13a02505af7dae01f5a4688bdb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/pickup.md",
+      "name": "/gaia pickup",
+      "description": "/gaia pickup",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/plan.md",
+      "name": "/gaia plan",
+      "description": "/gaia plan",
+      "audience": "adopter",
+      "content_hash": "9e63177bdfea74493d8ed5a3ca9672a8ee8b812710f02697f96187615ccbabe4",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/spec.md",
+      "name": "/gaia spec",
+      "description": "/gaia spec",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/wiki.md",
+      "name": "/gaia wiki",
+      "description": "/gaia wiki",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/wiki/consolidate.md",
+      "name": "/gaia wiki consolidate",
+      "description": "wiki-consolidate playbook",
+      "audience": "adopter",
+      "content_hash": "497ef750d4b5b084de0f92c5c22495c8554d60fee9bb34c081423d9d5050b1f2",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/wiki/lint.md",
+      "name": "/gaia wiki lint",
+      "description": "wiki-lint playbook",
+      "audience": "adopter",
+      "content_hash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "sub-route",
+      "path": ".claude/skills/gaia/references/wiki/sync.md",
+      "name": "/gaia wiki sync",
+      "description": "wiki-sync playbook",
+      "audience": "adopter",
+      "content_hash": "bbd089f8ab70238286a7169012cf2b8b3e618dd3aa55360f9fff6018505d73c3",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/README.md",
+      "name": "wiki/README.md",
+      "description": "GAIA React: LLM Wiki",
+      "audience": "mixed",
+      "content_hash": "888bc745837f9f70f0a6a9d4406b9960fd4a50c42376290e84c433e2e8949582",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/components/Form Choices.md",
+      "name": "wiki/components/Form Choices.md",
+      "description": "Form Choices",
+      "audience": "adopter",
+      "content_hash": "f3645fa47d96cc51d01b09512100e6d6488272c08925fb2b07ed7f73ac3814f9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/components/Form Field.md",
+      "name": "wiki/components/Form Field.md",
+      "description": "Form Field",
+      "audience": "adopter",
+      "content_hash": "b4047e5342cdd042deb2ba567d3279ab0c563f1aa120924edcd8c4c009893897",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/components/Form Layout.md",
+      "name": "wiki/components/Form Layout.md",
+      "description": "Form Layout",
+      "audience": "adopter",
+      "content_hash": "7a2949cd1f6415a4c494df6dd07924f3086b719065d3c26551b1947462e97fd2",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/components/Form Select.md",
+      "name": "wiki/components/Form Select.md",
+      "description": "Form Select",
+      "audience": "adopter",
+      "content_hash": "bf7ae57b864f61e9e0c2453fc2ade1acb519f2c0588ec3030e9ddaa8b1c267c2",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/components/Form Text Inputs.md",
+      "name": "wiki/components/Form Text Inputs.md",
+      "description": "Form Text Inputs",
+      "audience": "adopter",
+      "content_hash": "761d49fa3c8807c423357fc6eba0e88a08fcefdc67c238258bf98bf1d073dc82",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/components/Form YearMonthDay.md",
+      "name": "wiki/components/Form YearMonthDay.md",
+      "description": "Form YearMonthDay",
+      "audience": "adopter",
+      "content_hash": "284fefe3daec323dc5f220ee4339534a2730c0e0caa8260216ad091e7b52b4de",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/API Service Pattern.md",
+      "name": "wiki/concepts/API Service Pattern.md",
+      "description": "API Service Pattern",
+      "audience": "adopter",
+      "content_hash": "fe87920a39a95dcdcb08b70696117134015a3283e3a20e3913a867989a5eca1b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Accessibility.md",
+      "name": "wiki/concepts/Accessibility.md",
+      "description": "Accessibility",
+      "audience": "adopter",
+      "content_hash": "6436fe3f12aeb0dc15bd554905050cf4706566d25b2dc7d567cc64caf86e62fe",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Agentic Design.md",
+      "name": "wiki/concepts/Agentic Design.md",
+      "description": "Agentic Design",
+      "audience": "adopter",
+      "content_hash": "882c1432a36f053705caa2b6cca23fa48b14e3a11b6294c14d98226483d78dcd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Chromatic Opt-Out.md",
+      "name": "wiki/concepts/Chromatic Opt-Out.md",
+      "description": "Chromatic Opt-Out",
+      "audience": "adopter",
+      "content_hash": "eb9b3e3d7c2d59e88ae6a5a47245fe955e56cfad4afcd9c261646aca1f7186b8",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Claude Hooks.md",
+      "name": "wiki/concepts/Claude Hooks.md",
+      "description": "Claude Hooks",
+      "audience": "adopter",
+      "content_hash": "cb6dc6a0267c027627dfea3fbc1d2ce3eaa287ef2dd9ced8453c0d40509a9f93",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Claude Integration Conventions.md",
+      "name": "wiki/concepts/Claude Integration Conventions.md",
+      "description": "Claude Integration Conventions",
+      "audience": "adopter",
+      "content_hash": "1272c7b260d49281606bae8f597e0264fb6657d1a16620a856de1395d9fabb57",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Claude Skills.md",
+      "name": "wiki/concepts/Claude Skills.md",
+      "description": "Claude Skills",
+      "audience": "adopter",
+      "content_hash": "c97f7f29ce15ef3a687190c34512aeaf2c9ee6f291e5dd6bc092a535c5ec43f0",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Code Review Audit Agent.md",
+      "name": "wiki/concepts/Code Review Audit Agent.md",
+      "description": "Code Review Audit Agent",
+      "audience": "adopter",
+      "content_hash": "11812fd4a972392d378870d0f2c52d381eb43b06ba68917c8a04c7f2f42fb4dc",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Code Review Audit CI.md",
+      "name": "wiki/concepts/Code Review Audit CI.md",
+      "description": "Code Review Audit CI",
+      "audience": "adopter",
+      "content_hash": "984bba6393bc85c7e13af4c19de5628d2f4f6f3609fdc6a1b855c11869a105f6",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Coding Guidelines.md",
+      "name": "wiki/concepts/Coding Guidelines.md",
+      "description": "Coding Guidelines",
+      "audience": "adopter",
+      "content_hash": "3b8b8f6e925226e1ae9cc87109a11220149da4818c812f5b2e45c0a999ae68d4",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Component Testing.md",
+      "name": "wiki/concepts/Component Testing.md",
+      "description": "Component Testing",
+      "audience": "adopter",
+      "content_hash": "1392b847332804f50916720f06a82c45995d992bd7b10f9fa7cb9b78f8e9d87e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/ESLint Fixes.md",
+      "name": "wiki/concepts/ESLint Fixes.md",
+      "description": "ESLint Fixes",
+      "audience": "adopter",
+      "content_hash": "67bcc33bad9a828c9079fa9044f866993a83a459d9550f487e07a19de7f6e593",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Forensics.md",
+      "name": "wiki/concepts/Forensics.md",
+      "description": "Forensics",
+      "audience": "adopter",
+      "content_hash": "c0712894a6cb7cf5c3dac3f4ae402c10142ea4901f4d4a0524bf7c80a5a8b890",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/GAIA Audit.md",
+      "name": "wiki/concepts/GAIA Audit.md",
+      "description": "GAIA Audit",
+      "audience": "adopter",
+      "content_hash": "fc1206baedca1d47fe808540b162bc9efbde59abec03f3d299d841154e8d60e6",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/GAIA Handoff.md",
+      "name": "wiki/concepts/GAIA Handoff.md",
+      "description": "GAIA Handoff",
+      "audience": "adopter",
+      "content_hash": "8404fa71d8e1d70b27f5eea938add9dbf1201df25f8d22f6650f2bce065f60c9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/GAIA Philosophy.md",
+      "name": "wiki/concepts/GAIA Philosophy.md",
+      "description": "GAIA Philosophy",
+      "audience": "adopter",
+      "content_hash": "913876d84452597c821823e9112bfa82e71222f6c323ab266d77bb1afb79d35f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/GAIA Pickup.md",
+      "name": "wiki/concepts/GAIA Pickup.md",
+      "description": "GAIA Pickup",
+      "audience": "adopter",
+      "content_hash": "ce3a700ed7976202210d9cc95583c822f6f9d4b108b0f44fe663d8653d7f78ca",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/GAIA Plan.md",
+      "name": "wiki/concepts/GAIA Plan.md",
+      "description": "GAIA Plan",
+      "audience": "adopter",
+      "content_hash": "309979d32a2f9691bf89f1e98e5fd42f1f76884722737c38a3d692d2454cf517",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/GAIA Spec.md",
+      "name": "wiki/concepts/GAIA Spec.md",
+      "description": "GAIA Spec",
+      "audience": "adopter",
+      "content_hash": "c5d8a9bb88180d40f0b4577e63658befb14af55930f69d9a7a5b55930ca533b4",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Git Workflow.md",
+      "name": "wiki/concepts/Git Workflow.md",
+      "description": "Git Workflow",
+      "audience": "adopter",
+      "content_hash": "62e515fee6c288774eca89f50555219cd533aa4f05ff5f6c66bc0d886f946c51",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Init Workflow.md",
+      "name": "wiki/concepts/Init Workflow.md",
+      "description": "Init Workflow",
+      "audience": "adopter",
+      "content_hash": "3c0638fb2ed26b9a3dd7be4be263fb065fdddeeafac11c05ab5038a660646bda",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/PR Merge Workflow.md",
+      "name": "wiki/concepts/PR Merge Workflow.md",
+      "description": "PR Merge Workflow",
+      "audience": "adopter",
+      "content_hash": "4f3f5e004642ab6b48ea3b73ac7fea21a8f7c63c790d5211c7d5b53d317919a8",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Pre-commit Hooks.md",
+      "name": "wiki/concepts/Pre-commit Hooks.md",
+      "description": "Pre-commit Hooks",
+      "audience": "adopter",
+      "content_hash": "def9738703c84a48055bb5f13b517c0e163f4589cb06785388cca599fad26b18",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Release Workflow.md",
+      "name": "wiki/concepts/Release Workflow.md",
+      "description": "Release Workflow",
+      "audience": "contributor",
+      "content_hash": "52f597636f88dc0d8dec3f29b8a825f5dd1febc48bd2937d4a5faa43d66076b4",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Serena Integration.md",
+      "name": "wiki/concepts/Serena Integration.md",
+      "description": "Serena Integration",
+      "audience": "adopter",
+      "content_hash": "87d63de897151d7cb4cccfc5f82ea329df048d7d1a54095b25b1d964f86bfbe1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Task Orchestration.md",
+      "name": "wiki/concepts/Task Orchestration.md",
+      "description": "Task Orchestration",
+      "audience": "adopter",
+      "content_hash": "42fec10c022061e6eeae31f3e0ffaeae4a45940f8673945fa943894e5893492c",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Telemetry.md",
+      "name": "wiki/concepts/Telemetry.md",
+      "description": "Telemetry",
+      "audience": "adopter",
+      "content_hash": "4f12ee8de20349eadc23a0ed0b3f643333f33520c5a85c987f39128ee6292dc7",
+      "excluded_from_docs": true
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Test Runner.md",
+      "name": "wiki/concepts/Test Runner.md",
+      "description": "Test Runner Rule",
+      "audience": "adopter",
+      "content_hash": "9a357c11ab95fad2f7fe167d17053efbdca1697e17dec4322517072cbb487e66",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Update Merge.md",
+      "name": "wiki/concepts/Update Merge.md",
+      "description": "Update Merge",
+      "audience": "adopter",
+      "content_hash": "666fed252b783b5b2aefdcd2a8966aac74cb06c3dcbbc9eeb826344be298d91b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Update Workflow.md",
+      "name": "wiki/concepts/Update Workflow.md",
+      "description": "Update Workflow",
+      "audience": "adopter",
+      "content_hash": "33c699fe54686d67b1b26d98d06e384b43b0c84a045165fef985510537510a0d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Wiki Consolidate.md",
+      "name": "wiki/concepts/Wiki Consolidate.md",
+      "description": "Wiki Consolidate",
+      "audience": "adopter",
+      "content_hash": "e5e5454f87c7ea66c07b601e89b1c58adcbd1c3a26dff7424d2e125770e74ee5",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/concepts/Wiki Sync.md",
+      "name": "wiki/concepts/Wiki Sync.md",
+      "description": "Wiki Sync",
+      "audience": "adopter",
+      "content_hash": "5dfad5866d3df75ba7e89b731ebc8d8df0d22d63cd662beec75d4d93bcbfba12",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Bundle-time Scrub.md",
+      "name": "wiki/decisions/Bundle-time Scrub.md",
+      "description": "Bundle-time Scrub",
+      "audience": "contributor",
+      "content_hash": "726ff8e348268ae43c1ab923013390895fff03e8ba6bc909ca5945ba273b2f79",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Co-located Tests Folder.md",
+      "name": "wiki/decisions/Co-located Tests Folder.md",
+      "description": "Decision: Co-located `tests/` Subfolder",
+      "audience": "adopter",
+      "content_hash": "37404be25f8dc716beb7b229f497e0fdee57c9228f4c1daa4c60d9f1b73a466c",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Dark Mode Modernization.md",
+      "name": "wiki/decisions/Dark Mode Modernization.md",
+      "description": "Decision: Modernize Dark Mode (Cookie + Client Hints)",
+      "audience": "adopter",
+      "content_hash": "aa3623a3fd9be6f0685a3112b77d6f26b0b934c91d145f810da120241eef52a6",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/DragonScale Opt-Out.md",
+      "name": "wiki/decisions/DragonScale Opt-Out.md",
+      "description": "Decision: DragonScale Opt-Out",
+      "audience": "adopter",
+      "content_hash": "a7fa16bfd616c4e51f2f886c8eb2fb81b411a4efe6a743d7c26e19a12bdba8a4",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Forensics Triage Workflow.md",
+      "name": "wiki/decisions/Forensics Triage Workflow.md",
+      "description": "Decision: Forensics Triage Workflow",
+      "audience": "contributor",
+      "content_hash": "cdfa80db7b4f1ad6c4bd579ce85ea7c7aaa3f61756bef75f7eb36226990d1b33",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/No Component Library.md",
+      "name": "wiki/decisions/No Component Library.md",
+      "description": "Decision: No Component Library",
+      "audience": "adopter",
+      "content_hash": "1fd12d7c70211b0faa61e00a259f6c0d3e52e6bd3ecf1cf0b9ef4c900c1115b5",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Quality Gate.md",
+      "name": "wiki/decisions/Quality Gate.md",
+      "description": "Decision: Mandatory Quality Gate",
+      "audience": "adopter",
+      "content_hash": "9a11dc223a4e53b927020a33484e7a75e7e9bd4d3dbd9909314829e3f4ef3447",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Thin Routes.md",
+      "name": "wiki/decisions/Thin Routes.md",
+      "description": "Decision: Thin Routes, Fat Pages",
+      "audience": "adopter",
+      "content_hash": "20b4a79107f2d05bda210cff4400d958b6c214ada80eb9ad2cd3db7a42c44470",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/TypeScript Language Files.md",
+      "name": "wiki/decisions/TypeScript Language Files.md",
+      "description": "Decision: TypeScript Language Files Over JSON",
+      "audience": "adopter",
+      "content_hash": "dd06cdcc41d489958c3a89aee48ea873c342b130ef19a3834881bb69917da2ae",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/Wiki Management.md",
+      "name": "wiki/decisions/Wiki Management.md",
+      "description": "Wiki Management",
+      "audience": "adopter",
+      "content_hash": "7ef0dca2da792c7cebdc6690b7b5505a26db73e8f648fa4f9a685a5c60740fef",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/composeStory Pattern.md",
+      "name": "wiki/decisions/composeStory Pattern.md",
+      "description": "Decision: Test Components via Storybook `composeStory`",
+      "audience": "adopter",
+      "content_hash": "5a393d78f1a5bf54873b69f325a52cb52fe3edb5e3006f2a54abf07f615842f9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/pnpm.md",
+      "name": "wiki/decisions/pnpm.md",
+      "description": "Decision: pnpm as the Package Manager",
+      "audience": "adopter",
+      "content_hash": "fa265a0d810b118d7b7d56bd015c4174bf4b2a0e60c50ae37f65ae4fe708dd6e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/decisions/spec-kit Extension Strategy.md",
+      "name": "wiki/decisions/spec-kit Extension Strategy.md",
+      "description": "spec-kit Extension Strategy",
+      "audience": "adopter",
+      "content_hash": "c9f796816930be4ef5fe4d3d6c362b9b54f677c5ba39dd32e9a3c173dad4a69a",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Chromatic.md",
+      "name": "wiki/dependencies/Chromatic.md",
+      "description": "Chromatic",
+      "audience": "adopter",
+      "content_hash": "9c2b1cdd5f25f72cba8cf73c09b132c094d33b2e52a4c8a4560d33cfe2afdd67",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Conform.md",
+      "name": "wiki/dependencies/Conform.md",
+      "description": "Conform",
+      "audience": "adopter",
+      "content_hash": "44ae11256f7e4da566dc5c2b9436ba47bc1bf9372b3c2c9bfbf06c1e20d602bc",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Husky.md",
+      "name": "wiki/dependencies/Husky.md",
+      "description": "Husky + lint-staged",
+      "audience": "adopter",
+      "content_hash": "a711d029981ab47015cebc33f59063e7f513a2b04e3a25a0b53abcc3122c1d0e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Ky.md",
+      "name": "wiki/dependencies/Ky.md",
+      "description": "Ky",
+      "audience": "adopter",
+      "content_hash": "e97cbd19e5660015fcde3f8c426e236b74e022814d7cd4135d04b7f0a4ab27f6",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/MSW.md",
+      "name": "wiki/dependencies/MSW.md",
+      "description": "MSW",
+      "audience": "adopter",
+      "content_hash": "a7a132cbd0d9887013a744d8cf28290e08c72436c75955d2b18a5f56a387a381",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Playwright.md",
+      "name": "wiki/dependencies/Playwright.md",
+      "description": "Playwright",
+      "audience": "adopter",
+      "content_hash": "59d6be01d594cc2a938db75d901a46c49d57ae0810a236599d39e3719ce721eb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/React Router 7.md",
+      "name": "wiki/dependencies/React Router 7.md",
+      "description": "React Router 7",
+      "audience": "adopter",
+      "content_hash": "7c4ae988a49fded7cddd3031452deab238a70157399946e662473838f7dcab73",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/React Testing Library.md",
+      "name": "wiki/dependencies/React Testing Library.md",
+      "description": "React Testing Library",
+      "audience": "adopter",
+      "content_hash": "b1a5cf93eab7fd9923c365afb924825330877363a95b7487f9b25af94daf658d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Serena.md",
+      "name": "wiki/dependencies/Serena.md",
+      "description": "Serena",
+      "audience": "adopter",
+      "content_hash": "4592979349184e2e265fc483733b90f421ac41bceb12c28337c2956fe56f25f1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Storybook.md",
+      "name": "wiki/dependencies/Storybook.md",
+      "description": "Storybook",
+      "audience": "adopter",
+      "content_hash": "80086f11cdeb02dd87fc70badf357a571c46412544ee18d4a3f9e87a9541476a",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Tailwind.md",
+      "name": "wiki/dependencies/Tailwind.md",
+      "description": "Tailwind",
+      "audience": "adopter",
+      "content_hash": "70a1747925a47b6ee797b2e3f6ad7bbba49e8bf2506fdb25dade43e31f80d6a1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Vitest.md",
+      "name": "wiki/dependencies/Vitest.md",
+      "description": "Vitest",
+      "audience": "adopter",
+      "content_hash": "fed2aa1a1f00e1f03bb6b5b8a7803c4f473ba8a12b3d166997746d21b32ae4c0",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/Zod.md",
+      "name": "wiki/dependencies/Zod.md",
+      "description": "Zod",
+      "audience": "adopter",
+      "content_hash": "38a03dd255ec86b8b7cd01a220ec8b2dd25a6f40df3770bd5fad9a993f5cec47",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/gaia-lint.md",
+      "name": "wiki/dependencies/gaia-lint.md",
+      "description": "@gaia-react/lint",
+      "audience": "adopter",
+      "content_hash": "c7e22cfd1e2b0c334d111fb1643e6930c59c58749fcdee24a0a55aa6247a30cd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/i18next.md",
+      "name": "wiki/dependencies/i18next.md",
+      "description": "i18next",
+      "audience": "adopter",
+      "content_hash": "b74a80f78e2710aaa465bcfae588e130ec9926d8abc32d1651f3b2b4851be71b",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/knip.md",
+      "name": "wiki/dependencies/knip.md",
+      "description": "knip",
+      "audience": "adopter",
+      "content_hash": "c03940ffa21051dff65ac1bdc1ca514b55559257b4477422ef08acdd62b4ee72",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/react-icons.md",
+      "name": "wiki/dependencies/react-icons.md",
+      "description": "react-icons",
+      "audience": "adopter",
+      "content_hash": "b7103ef03702ceb5addec8896a0a170d3a948777cb2c81ab4a49789fd9ab85a1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/remix-flat-routes.md",
+      "name": "wiki/dependencies/remix-flat-routes.md",
+      "description": "remix-flat-routes",
+      "audience": "adopter",
+      "content_hash": "a83037c5dc7cfede139bf5cff0a8e189687b8ae4ab53709abcb7529d499e6fef",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/remix-i18next.md",
+      "name": "wiki/dependencies/remix-i18next.md",
+      "description": "remix-i18next",
+      "audience": "adopter",
+      "content_hash": "e7b05124c138b95028c8c58f20c6fc187c3cfb31e39e4d17cbf1ec79a0796e50",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/remix-toast.md",
+      "name": "wiki/dependencies/remix-toast.md",
+      "description": "remix-toast + Sonner",
+      "audience": "adopter",
+      "content_hash": "70bcdd8abdcb0620add3dc726630dba14ab0356a8b3439607b7b199aa48bac36",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/dependencies/spec-kit.md",
+      "name": "wiki/dependencies/spec-kit.md",
+      "description": "spec-kit",
+      "audience": "adopter",
+      "content_hash": "059e4474d5e1e2893bac908f9fdfa9d730689628bfd7794353444a6e0b090520",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/entities/GAIA.md",
+      "name": "wiki/entities/GAIA.md",
+      "description": "GAIA",
+      "audience": "contributor",
+      "content_hash": "45905837b31831575a132cac37ea091e5f6f4fb65b0bd8156c6a4dc80e51f6c5",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/entities/Steven Sacks.md",
+      "name": "wiki/entities/Steven Sacks.md",
+      "description": "Steven Sacks",
+      "audience": "contributor",
+      "content_hash": "977e03dfbd741d906164fc836413ff512f05f3f0bbfbd631b866623b1c9e1119",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/flows/Form Submit Flow.md",
+      "name": "wiki/flows/Form Submit Flow.md",
+      "description": "Form Submit Flow",
+      "audience": "adopter",
+      "content_hash": "36d5eae5cdf39eb77e3a2179dfbbc859b4cc710e62ec32da20f6d113b1957370",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/flows/Language Flow.md",
+      "name": "wiki/flows/Language Flow.md",
+      "description": "Language Flow",
+      "audience": "adopter",
+      "content_hash": "866014c5fc2a4dadea015ea6649869e2773c7d84262e0d752bc21d33c3e6903f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/flows/Theme Flow.md",
+      "name": "wiki/flows/Theme Flow.md",
+      "description": "Theme Flow (Dark Mode)",
+      "audience": "adopter",
+      "content_hash": "1e11561b80fe27a40992bb3fe9394f359e69b8dc492a6a536f54613f2f225b20",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/hot.md",
+      "name": "wiki/hot.md",
+      "description": "Recent Context",
+      "audience": "adopter",
+      "content_hash": "45cc97f880c48627555e16afb6691974a1a8c0b2e5f33e3edcb02732146b1468",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/index.md",
+      "name": "wiki/index.md",
+      "description": "Index",
+      "audience": "mixed",
+      "content_hash": "b6f5f63e0fef2cfdaa3f755b670d612fe3f752feccd97d528d49ab3b55a27c6d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/log.md",
+      "name": "wiki/log.md",
+      "description": "Log",
+      "audience": "adopter",
+      "content_hash": "da7144961847fd2b96a84967bd2957b85d52501c71dd975fdf506f7dd6366e16",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/consolidate-report-2026-05-07.md",
+      "name": "wiki/meta/consolidate-report-2026-05-07.md",
+      "description": "Consolidate Report \u2014 2026-05-07",
+      "audience": "contributor",
+      "content_hash": "e58a051ea0d07978941e1e9afe4768791dff11e5643d5a4e8c7ebf47cee42522",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/consolidate-report-2026-05-08.md",
+      "name": "wiki/meta/consolidate-report-2026-05-08.md",
+      "description": "Consolidate Report \u2014 2026-05-08",
+      "audience": "contributor",
+      "content_hash": "1c49b0b0fc1cbe38a32f21b35290ad9e6bd4a80e6607969710009355ea3b5098",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/dashboard.md",
+      "name": "wiki/meta/dashboard.md",
+      "description": "Wiki Dashboard",
+      "audience": "contributor",
+      "content_hash": "4e2d4ff31315d91651d7d4cba922db0eb252909d1d967f0a13a8d9cfef3c48e9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-04-21.md",
+      "name": "wiki/meta/lint-report-2026-04-21.md",
+      "description": "Wiki Lint Report \u2014 2026-04-21",
+      "audience": "contributor",
+      "content_hash": "ba9ff888e56dfa83acfa0f061d077bd950b2ae481271609f1ea9a49fa6aa368d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-04-26.md",
+      "name": "wiki/meta/lint-report-2026-04-26.md",
+      "description": "Wiki Lint Report \u2014 2026-04-26",
+      "audience": "contributor",
+      "content_hash": "c95d42f963053bb272e7886f6c5dd6bec09cfb31560289a1b058b2f05acbe19d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-04-27.md",
+      "name": "wiki/meta/lint-report-2026-04-27.md",
+      "description": "Wiki Lint Report \u2014 2026-04-27",
+      "audience": "contributor",
+      "content_hash": "d6c6be57eb8dae5d7c0a75e87c9df126a48af5d0efc39c54e8d462de1df4e789",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-05-01.md",
+      "name": "wiki/meta/lint-report-2026-05-01.md",
+      "description": "Wiki Lint Report \u2014 2026-05-01",
+      "audience": "contributor",
+      "content_hash": "311620a33ea61526e7bb1f9337a77e8a026dfcc7c1c8057675b69a5506f26020",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-05-03.md",
+      "name": "wiki/meta/lint-report-2026-05-03.md",
+      "description": "Lint Report: 2026-05-03",
+      "audience": "contributor",
+      "content_hash": "ae8ed11aac52983ac4b0b626d984d7996132464a3c837ae4f31e154a9fe75938",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-05-04.md",
+      "name": "wiki/meta/lint-report-2026-05-04.md",
+      "description": "Lint Report: 2026-05-04",
+      "audience": "contributor",
+      "content_hash": "937e9aca477d5b57dba6ebd07fa7c069c76862f53d6e893296460a7dd89b00bb",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-05-06.md",
+      "name": "wiki/meta/lint-report-2026-05-06.md",
+      "description": "Lint Report: 2026-05-06",
+      "audience": "contributor",
+      "content_hash": "031432cfa6487fa40fa6c6d3e4ffaa79420de38c97e93a56f070dd86985a6245",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-05-07.md",
+      "name": "wiki/meta/lint-report-2026-05-07.md",
+      "description": "Lint Report: 2026-05-07",
+      "audience": "contributor",
+      "content_hash": "f7e9567ccdad08cdeae01a303d9ff38e1f0f436e64c01867a9f50280f7c121c2",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/meta/lint-report-2026-05-08.md",
+      "name": "wiki/meta/lint-report-2026-05-08.md",
+      "description": "Lint Report: 2026-05-08",
+      "audience": "contributor",
+      "content_hash": "d92d89b79f72fe41f48ac73b915febd25eae4d5c3467f4ee1dcba12d90dadf50",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/CLI Scaffolding.md",
+      "name": "wiki/modules/CLI Scaffolding.md",
+      "description": "CLI Scaffolding",
+      "audience": "adopter",
+      "content_hash": "8218176d232427b13f3143b46e2144ce08a58df379fcfaf660b940ea5823515f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Claude Integration.md",
+      "name": "wiki/modules/Claude Integration.md",
+      "description": "Claude Integration",
+      "audience": "adopter",
+      "content_hash": "e70cff0f904b135c85e43dcf5cc0ae9e38c70d698f4ea1960f6c1f57fefe95b9",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Components.md",
+      "name": "wiki/modules/Components.md",
+      "description": "Components",
+      "audience": "adopter",
+      "content_hash": "031bc6681a2c8333ff7a83c55ccfc4f8acc36311550770127230dc8cd18aace8",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Folder Structure.md",
+      "name": "wiki/modules/Folder Structure.md",
+      "description": "Folder Structure",
+      "audience": "adopter",
+      "content_hash": "665b8424e9f157fb81452782d7dd7da909132ccf278b65c68501e3dad579d9d1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Form Components.md",
+      "name": "wiki/modules/Form Components.md",
+      "description": "Form Components",
+      "audience": "adopter",
+      "content_hash": "29b846671c9874f2cbb0186ecef88b126bce6fc2fa52b64e20fd7dcf08e64776",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Hooks.md",
+      "name": "wiki/modules/Hooks.md",
+      "description": "Hooks",
+      "audience": "adopter",
+      "content_hash": "cd2f09ca9a61c888773127191a19ae48bda38a09789440f0555268450e1d2d54",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/MSW Handlers.md",
+      "name": "wiki/modules/MSW Handlers.md",
+      "description": "MSW (Mock Service Worker)",
+      "audience": "adopter",
+      "content_hash": "feb701104fcd7c1203bd9244feef10ed56bf6b0617f3337096ef67e24fa960c4",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Middleware.md",
+      "name": "wiki/modules/Middleware.md",
+      "description": "Middleware",
+      "audience": "adopter",
+      "content_hash": "6df2567693c3242e1d1d76662cfeb1be6dbff71ec01c1c42b93b21bb506dadac",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Pages.md",
+      "name": "wiki/modules/Pages.md",
+      "description": "Pages",
+      "audience": "adopter",
+      "content_hash": "1492c9d6ca4e66922d56ff77a48e676defffaf3bb05f6b4ab25e275704db5252",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Routing.md",
+      "name": "wiki/modules/Routing.md",
+      "description": "Routing",
+      "audience": "adopter",
+      "content_hash": "c150a7c29873623d0677d46c3eb4b0ab677f2ff564b2335ba98e44b878bd0b30",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Services.md",
+      "name": "wiki/modules/Services.md",
+      "description": "Services",
+      "audience": "adopter",
+      "content_hash": "2bffc0c07be9d23dc80654ed256eee8a03c17c064f412268b864e234ee59925d",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Sessions.md",
+      "name": "wiki/modules/Sessions.md",
+      "description": "Sessions",
+      "audience": "adopter",
+      "content_hash": "d9365dd1f7351bdd4e3b78ffcb895328e8f6140b22fb29f79ee3d08882b08ccc",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/State.md",
+      "name": "wiki/modules/State.md",
+      "description": "State",
+      "audience": "adopter",
+      "content_hash": "767bc7bc6f7babeca110642527c30309cf60d2df0b7cd3fd0962ee397395fc0a",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Storybook Stories.md",
+      "name": "wiki/modules/Storybook Stories.md",
+      "description": "Storybook Stories",
+      "audience": "adopter",
+      "content_hash": "0dac55584ebc642b89e98e2ebb11c71ab965d7a062172ca6ace66b0b38873c1e",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Styles.md",
+      "name": "wiki/modules/Styles.md",
+      "description": "Styles",
+      "audience": "adopter",
+      "content_hash": "38ae72680bcbe979f07897b544c7f7af3046ecc57a060a91517041aa9660431f",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Testing.md",
+      "name": "wiki/modules/Testing.md",
+      "description": "Testing",
+      "audience": "adopter",
+      "content_hash": "97eb4b201393a17ee9339f57ba06c363860a6c3b47a760ce1cf182fd2af00599",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/Utils.md",
+      "name": "wiki/modules/Utils.md",
+      "description": "Utils",
+      "audience": "adopter",
+      "content_hash": "cdb7c210c543d3eaf7eeab908b002fc1db5a2ce72fb71f762aaee5be17c021bd",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/modules/i18n.md",
+      "name": "wiki/modules/i18n.md",
+      "description": "i18n",
+      "audience": "adopter",
+      "content_hash": "efe3b2a41a1e0e390cd1fed364080646a7a3a56935145726fef8040fc9c633ca",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "wiki-page",
+      "path": "wiki/overview.md",
+      "name": "wiki/overview.md",
+      "description": "GAIA React",
+      "audience": "adopter",
+      "content_hash": "9f488147cd2377ad7bc09a1c0e1e629759fd69d0707ed84b3c608fa768a54327",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/chromatic.yml",
+      "name": "chromatic.yml",
+      "description": "Chromatic",
+      "audience": "adopter",
+      "content_hash": "e1df407b716e0b0bbb3fcb1d3de35e759b5702c47a2f672c09671fed6342fe38",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/cli-tests.yml",
+      "name": "cli-tests.yml",
+      "description": "CLI Tests",
+      "audience": "contributor",
+      "content_hash": "472c5a8ae51e4343f01952b3c75e2eae1c1544e0212eb6748dcc8255f75c7619",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/code-review-audit.yml",
+      "name": "code-review-audit.yml",
+      "description": "Code Review Audit",
+      "audience": "adopter",
+      "content_hash": "e520bfee77a32002d9798212b5b3fb36e06a3ecbcd0e55c9bb67358125e626d1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/distribution.yml",
+      "name": "distribution.yml",
+      "description": "Distribution",
+      "audience": "contributor",
+      "content_hash": "ab91eb12a6c8ac0c4620baec5f44cb599db17280def33e673ca8df4cade37af3",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/forensics-triage.yml",
+      "name": "forensics-triage.yml",
+      "description": "Forensics Triage",
+      "audience": "contributor",
+      "content_hash": "08fa217b28adb5225e6134989fd3c1ef64e1e84e3cd5c3b8b297ca8033eeacc1",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/release.yml",
+      "name": "release.yml",
+      "description": "Release",
+      "audience": "contributor",
+      "content_hash": "3c4055208c2de07e1b91f291170e9dddd7289e2465df6064e9383dffe0a204a0",
+      "excluded_from_docs": false
+    },
+    {
+      "kind": "workflow",
+      "path": ".github/workflows/tests.yml",
+      "name": "tests.yml",
+      "description": "Tests",
+      "audience": "adopter",
+      "content_hash": "d67abed1b7f5c197377f5bd026ce05bc80e28bc753212b790f91ec065d614f59",
+      "excluded_from_docs": false
+    }
+  ]
 }

--- a/.claude/skills/source-survey/SKILL.md
+++ b/.claude/skills/source-survey/SKILL.md
@@ -27,7 +27,8 @@ This skill does not write docs. It reports drift so the user can decide what to 
 ## Outputs
 
 - A structured markdown report printed to the conversation.
-- A *suggested* updated snapshot (printed as a fenced JSON block). Do not write it. Tell the user how to commit it.
+- A structured markdown report printed to the conversation.
+- The updated snapshot written directly to `~/Development/gaia-react/docs/.claude/audit/source-state.json` via script or Write tool. Never print the JSON to chat.
 
 ## Procedure
 
@@ -292,23 +293,13 @@ hash rule: frontmatter + first 40 body lines (sha256)
 - <one-line description of an item the survey couldn't classify with confidence>
 ```
 
-### Step 8 — Print the suggested next snapshot
+### Step 8 — Write the snapshot to disk
 
-Append to the report:
+Write the updated snapshot JSON directly to `~/Development/gaia-react/docs/.claude/audit/source-state.json`. Do NOT print the JSON to chat. Use a script (bash/python) or the Write tool. Confirm to the user with a single line: `snapshot written: N items → docs/.claude/audit/source-state.json`
 
-```
-## suggested next snapshot
-```
+### Step 9 — Tell the user it's done
 
-Then a fenced JSON block matching the snapshot schema with the current items. Do NOT write to disk.
-
-### Step 9 — Tell the user how to commit
-
-End with this exact line, swapping in the actual command if the user has already wired one:
-
-```
-To accept this snapshot, copy the JSON block above to ~/Development/gaia-react/docs/.claude/audit/source-state.json. Re-running source-survey with no source change must produce identical output.
-```
+End with one line confirming the file was written and the gaia commit it was captured against.
 
 ## Idempotency rules
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,6 +26,58 @@ export default defineConfig({
 					label: 'Start here',
 					items: [{ label: 'Introduction', slug: 'index' }],
 				},
+				{
+					label: 'Getting started',
+					items: [
+						{ label: 'Install', slug: 'getting-started/install' },
+						{ label: '/gaia-init walkthrough', slug: 'getting-started/gaia-init' },
+						{ label: '/setup-gaia walkthrough', slug: 'getting-started/setup-gaia' },
+					],
+				},
+				{
+					label: 'Commands',
+					items: [{ label: 'Overview', slug: 'commands' }],
+				},
+				{
+					label: '/gaia',
+					items: [
+						{ label: 'Overview', slug: 'gaia' },
+						{ label: '/gaia plan', slug: 'gaia/plan' },
+						{ label: '/gaia spec', slug: 'gaia/spec' },
+						{ label: '/gaia audit', slug: 'gaia/audit' },
+						{ label: '/gaia handoff and pickup', slug: 'gaia/handoff-pickup' },
+						{ label: '/gaia forensics', slug: 'gaia/forensics' },
+						{ label: '/gaia wiki', slug: 'gaia/wiki' },
+					],
+				},
+				{
+					label: 'Skills',
+					items: [
+						{ label: 'Overview', slug: 'skills' },
+						{ label: 'Code skills', slug: 'skills/code' },
+						{ label: 'Scaffolders', slug: 'skills/scaffolders' },
+						{ label: 'Maintenance', slug: 'skills/maintenance' },
+					],
+				},
+				{
+					label: 'Reference',
+					items: [
+						{ label: 'Hooks', slug: 'reference/hooks' },
+						{ label: 'Rules', slug: 'reference/rules' },
+						{ label: 'Agents', slug: 'reference/agents' },
+					],
+				},
+				{
+					label: 'Contributors',
+					items: [
+						{ label: 'Overview', slug: 'contributors' },
+						{ label: 'Release', slug: 'contributors/release' },
+						{ label: 'Health audit', slug: 'contributors/health-audit' },
+						{ label: 'CLI surface', slug: 'contributors/cli' },
+						{ label: 'CI workflows', slug: 'contributors/ci' },
+						{ label: 'Wiki internals', slug: 'contributors/wiki' },
+					],
+				},
 			],
 		}),
 	],

--- a/src/content/docs/commands/index.mdx
+++ b/src/content/docs/commands/index.mdx
@@ -1,0 +1,40 @@
+---
+title: Slash commands
+description: Top-level slash commands for GAIA projects. /gaia-init, /setup-gaia, and the /gaia router.
+sidebar:
+  order: 1
+---
+
+GAIA ships two top-level slash commands at the root of `.claude/commands/`. Both are first-run setup. Day-to-day work runs through the [`/gaia`](/gaia/) router skill.
+
+## /gaia-init
+
+One-shot bootstrap for a fresh project from the GAIA template. Renames the project, strips GAIA branding, configures i18n (or strips it out), wires the statusline, installs Claude tools and plugins, registers spec-kit, and resets the wiki to a clean slate.
+
+Run once, on the project the maintainer just created with `npx create-gaia`. Idempotent: failed steps resume from `.gaia/init-state.json` via `gaia init resume`.
+
+The [`/gaia-init` walkthrough](/getting-started/gaia-init/) covers every prompt and what it sets.
+
+## /setup-gaia
+
+Per-machine setup for a clone of an already-initialized GAIA project. Installs the same Claude tools and plugins, registers spec-kit, sets the statusline executable bit, copies `.env.example` to `.env`. Idempotent: completed steps are recorded in `.gaia/local/setup-state.json` via `gaia setup mark-step`.
+
+Run once per developer, per clone. The statusline displays `Run /setup-gaia` until it has been completed.
+
+The [`/setup-gaia` walkthrough](/getting-started/setup-gaia/) covers every step and how to resume on failure.
+
+The slash command name intentionally does not start with `gaia-`, so it does not pollute the `/gaia` autocomplete namespace. That namespace is reserved for the day-to-day workflows.
+
+## /gaia (router)
+
+`/gaia` is itself a router skill, not a top-level command. It dispatches to GAIA's day-to-day workflows:
+
+- [`/gaia plan`](/gaia/plan/)
+- [`/gaia spec`](/gaia/spec/)
+- [`/gaia audit`](/gaia/audit/)
+- `/gaia handoff`
+- `/gaia pickup`
+- `/gaia forensics`
+- `/gaia wiki` (with sub-args `sync`, `consolidate`, `lint`)
+
+See the [`/gaia` router page](/gaia/) for the full sub-route map and help text.

--- a/src/content/docs/contributors/ci.mdx
+++ b/src/content/docs/contributors/ci.mdx
@@ -1,0 +1,66 @@
+---
+title: CI workflows
+description: Contributor-only GitHub Actions workflows. Release, CLI tests, distribution harness, and forensics triage.
+sidebar:
+  order: 5
+---
+
+Four CI workflows are excluded from the adopter tarball by `.gaia/release-exclude`. They run only on the GAIA template repo's clone. The other three workflows (`chromatic.yml`, `tests.yml`, `code-review-audit.yml`) ship to adopters and are out of scope here.
+
+## release.yml
+
+Triggers on `v*.*.*` tag pushes. Builds and publishes the adopter tarball.
+
+The job sequence:
+
+1. **Checkout** at the tag with full git history.
+2. **Derive version** from the tag ref.
+3. **Verify `.gaia/VERSION` matches the tag.** Fails the workflow if they diverge, so a stray tag cannot publish.
+4. **Extract the CHANGELOG section** for the release. Fails if the version's heading is missing.
+5. **Verify the manifest is fresh** to confirm `.gaia/manifest.json` reflects the current file set. Catches stale manifests.
+6. **Stage the release tree.** Drives the file set from `git ls-files` so untracked artifacts stay out, then filters `.gaia/release-exclude` patterns. Copies the surviving files into `/tmp/gaia-<tag>/` with `rsync`.
+7. **Bundle-time scrub** of the staging directory: `gaia:maintainer-only` blocks are stripped and leak checks run.
+8. **Verify runtime dependencies** against the staged tree.
+9. **Distribution test gate** runs `.gaia/tests/distribution/run-all.sh` against an independently-staged tree (Layers 0+1+2). Halts the release if any scenario fails.
+10. **Build the tarball** as `gaia-<tag>.tar.gz`.
+11. **Create the GitHub Release** with the extracted CHANGELOG section as release notes.
+
+The pre-publish distribution gate uses the org `CLAUDE_CODE_OAUTH_TOKEN` secret. A broken release cannot publish: the gate runs before `gh release create`.
+
+## cli-tests.yml
+
+Triggers on both `push` to `main` and `pull_request` against `main`. The job is gated to `pull_request` events via a job-level `if:` condition; push events keep the required status check green on merge commits without rerunning anything. Runs the Vitest suite under `.gaia/cli/`.
+
+PRs that don't touch `.gaia/cli/**` or this workflow file report green without installing or running anything. The path filter is `dorny/paths-filter`.
+
+When the filter triggers, the job:
+
+1. Sets up pnpm (pinned to v4.4.0 because v6 surfaces an `ERR_PNPM_IGNORED_BUILDS` regression on the `pnpm -C .gaia/cli install --frozen-lockfile` invocation).
+2. Sets up Node from `.node-version` with pnpm cache keyed to `.gaia/cli/pnpm-lock.yaml`.
+3. Installs CLI dependencies with `--frozen-lockfile`.
+4. Runs `pnpm -C .gaia/cli typecheck`.
+5. Runs `pnpm -C .gaia/cli test --run`.
+
+The required-check posture is intentional: contributors who don't touch the CLI source see the check as required-and-green without paying the install cost.
+
+## distribution.yml
+
+Triggers only on `workflow_dispatch`. Used to run the `.gaia/tests/distribution/` harness on a feature branch for ad-hoc verification of harness changes themselves.
+
+The production gate against the harness lives inside `release.yml`. There is no automatic trigger on this workflow on purpose: `release.published` fires after publish (too late to gate a release), and `pull_request` is unsafe for forks.
+
+The workflow does not use `pull_request_target`. That trigger exposes secrets to fork PRs, which would let any contributor exfiltrate `CLAUDE_CODE_OAUTH_TOKEN`.
+
+The job verifies the bundled `.gaia/cli/gaia` is present and executable, then runs `bash .gaia/tests/distribution/run-all.sh` with a 15-minute timeout.
+
+## forensics-triage.yml
+
+Triggers on issue events (`opened`, `labeled`) when the issue carries the `gaia-forensics` label. Runs autonomous Claude Code triage against the issue.
+
+Permissions are scoped per-job: `issues: write`, `contents: write`, `pull-requests: write`, `actions: read`, `id-token: write`. Concurrency is keyed per-issue.
+
+The workflow has helpers under `.github/forensics/`: scope checks, classifier prompts, fixtures, and bats tests. All of `.github/forensics/` is contributor-only and excluded from the adopter tarball.
+
+Steps include an idempotency early-exit (skip if `gaia-triaged` is already on the issue), classification, optional apply-fix path that runs the project quality gate, and a final fallback step that ensures `gaia-triaged` lands on the issue regardless of path.
+
+The workflow is on the canonical denylist: future autonomous triage runs must not modify it. The workflow's `check-scope.sh` rejects any attempt to edit any path under `.github/workflows/`. Self-modifying triage is a security boundary violation.

--- a/src/content/docs/contributors/cli.mdx
+++ b/src/content/docs/contributors/cli.mdx
@@ -1,0 +1,112 @@
+---
+title: CLI surface
+description: Reference for the gaia binary subcommands invoked by skills, hooks, and slash commands. Source layout for contributors working on the CLI.
+sidebar:
+  order: 4
+---
+
+The `gaia` binary is the bundled CLI that ships with the adopter tarball at `.gaia/cli/gaia`. Adopters do not invoke it directly in normal use. Skills, hooks, and slash commands invoke it for them.
+
+Contributors working on the CLI source need the surface map. Source lives under `.gaia/cli/src/` (contributor-only, excluded from the adopter tarball). The bundle is rebuilt by `pnpm --filter @gaia-react/cli bundle`.
+
+## Build layout
+
+Two binaries get bundled:
+
+- `.gaia/cli/gaia`: adopter binary. Entry point: `src/index.ts`. Ships in the tarball.
+- `.gaia/cli/gaia-maintainer`: maintainer binary. Entry point: `src/index.maintainer.ts`. Excluded from the tarball.
+
+The adopter binary's `src/index.ts` does not import any maintainer-only handler, so esbuild tree-shakes maintainer surface out of the adopter bundle.
+
+## Top-level subcommands
+
+All subcommands print a help block on `--help`, `-h`, or `help`. Source path links point at the per-subcommand router under `.gaia/cli/src/`.
+
+### `gaia init`
+
+Source: `.gaia/cli/src/init/index.ts`
+
+Per-step handlers consumed by `/gaia-init`. Each handler reads and writes `.gaia/init-state.json` so the slash command can resume on failure.
+
+```
+gaia init strip-branding --title <T>
+gaia init configure-i18n --locales <list> --strip <bool>
+gaia init rename --title <T> --kebab <K>
+gaia init wire-statusline --mode <global|project|skip>
+gaia init finalize
+gaia init resume [--from-step <N>]
+```
+
+### `gaia scaffold`
+
+Source: `.gaia/cli/src/scaffold/index.ts`
+
+Code generators invoked by the `new-component`, `new-hook`, `new-route`, and `new-service` skills. Each generator reads templates from `.gaia/cli/src/scaffold/templates/`.
+
+```
+gaia scaffold component <Name>
+gaia scaffold hook <useFoo>
+gaia scaffold route <name>
+gaia scaffold service <name>
+```
+
+### `gaia setup`
+
+Source: `.gaia/cli/src/setup/index.ts`
+
+Per-machine clone setup primitives invoked by `/setup-gaia`. The slash command orchestrates externally-shelled installs (React Doctor, Playwright CLI, Serena MCP, plugins, spec-kit) and calls these primitives to record progress in `.gaia/local/setup-state.json`.
+
+```
+gaia setup status [--json]
+gaia setup mark-step <step>
+gaia setup finalize [--force]
+gaia setup link-worktree [--json]
+```
+
+### `gaia update`
+
+Source: `.gaia/cli/src/update/index.ts`
+
+Wired by the `/update-gaia` skill for the deterministic byte-level merge step.
+
+```
+gaia update merge --baseline <dir> --latest <dir> --manifest <path> [--json]
+```
+
+The skill drives tarball fetching and user-facing prompts; the CLI handles per-manifest-entry classification and three-way file compare so the skill never reads bytes per entry.
+
+### `gaia wiki`
+
+Source: `.gaia/cli/src/wiki/index.ts`
+
+Wiki-state primitives consumed by the `/gaia wiki` skill family (`sync`, `consolidate`, `lint`). The primitives are deterministic; the slash commands orchestrate them.
+
+```
+gaia wiki state [--json]
+gaia wiki commit-classify --since <sha> [--json]
+gaia wiki state-init <sha>
+gaia wiki state-bump <field> <value>
+gaia wiki log-prepend --sha <h> --decision <D> --reason "..."
+gaia wiki page-index [--json]
+gaia wiki orphans
+gaia wiki near-collisions [--max-distance N]
+gaia wiki dead-paths [--json]
+gaia wiki sync land [--branch-aware]
+```
+
+`state-init <sha>` refuses if `wiki/.state.json` already exists. `state-bump` performs an atomic single-field update. `sync land` lands staged wiki changes via the correct branch strategy.
+
+## Where to find tests
+
+Per-subcommand test files sit alongside the source: `component.test.ts` next to `component.ts`, etc. The test runner is Vitest. Run from the CLI workspace:
+
+```bash
+pnpm -C .gaia/cli typecheck
+pnpm -C .gaia/cli test --run
+```
+
+Test fixtures live under `.gaia/cli/test-fixtures/`.
+
+## Surfaces excluded from this reference
+
+Some namespaces in the source are deliberately undocumented in public contributor docs and are not listed above. They remain visible in the source itself; this page intentionally does not enumerate them.

--- a/src/content/docs/contributors/health-audit.mdx
+++ b/src/content/docs/contributors/health-audit.mdx
@@ -1,0 +1,58 @@
+---
+title: Health audit
+description: /health-audit runs an autonomous audit, fix, and re-audit loop against the GAIA template repo with circuit breakers and escalation criteria.
+sidebar:
+  order: 3
+---
+
+`/health-audit` is the autonomous audit + auto-heal loop for the GAIA template repo. It is contributor-only. The slash command file (`.claude/commands/health-audit.md`) and the supporting infrastructure under `.gaia/cli/health/` are excluded from the adopter tarball.
+
+Adopters audit their own app via the `code-review-audit` agent. They never run `/health-audit`.
+
+## What it does
+
+`/health-audit` runs up to three audit-fix-audit cycles. Each cycle:
+
+1. Spawns a fresh Triager.
+2. The Triager runs the Audit Team in parallel across buckets A-D.
+3. Findings get written to `.gaia/local/audit/c<N>/findings.json`.
+4. If clean (zero findings + Bucket D reports A+ readiness), the cycle exits with grade A+.
+5. Otherwise, the Triager classifies findings, compares fingerprints against the previous cycle to detect oscillation, and dispatches Fixers in lane-aware parallel.
+6. Fixers complete; the Triager reports post-fix state; the team shuts down; the next cycle starts.
+
+A fresh Triager per cycle prevents prior-cycle findings from bleeding into verification.
+
+## Where the runbook lives
+
+The orchestrator reads `.gaia/cli/health/runbook.md` end-to-end before running. The runbook codifies role structure, bucket definitions, fixer lane mapping, model selection, circuit breakers, and escalation criteria. The taxonomy of findings lives at `.gaia/cli/health/taxonomy.md`.
+
+Both files are excluded from the adopter tarball via the `.gaia/cli/health/` directory rule in `.gaia/release-exclude`.
+
+## Circuit breakers
+
+A Fixer dispatch pauses for human-confirm if the proposed fix:
+
+- Touches more than 100 lines.
+- Modifies `.gaia/release-exclude`.
+- Modifies `.claude/rules/`.
+- Removes a check from `.gaia/release-scrub.yml`.
+- Edits `.gaia/cli/health/taxonomy.md` "Decided / not findings" entries.
+
+If the human refuses the fix, the orchestrator escalates.
+
+## Reports
+
+On a clean exit the orchestrator prints:
+
+```
+HEALTH AUDIT: A+
+Cycles: <N>
+Findings closed: <count> (per cycle: <breakdown>)
+Artifacts: cleaned (.gaia/local/audit/c* removed)
+```
+
+On escalation it preserves all `c*/` directories and prints the outstanding findings with fingerprints and the escalation reason (max-loops hit, oscillation detected, circuit breaker tripped, unclassified finding, or fixer unable to fix).
+
+## When contributors run it
+
+Run `/health-audit` against the template repo before cutting a release, after merging changes that touched the CLI source or shipped Claude surface, or when investigating drift between the template and its own internal rules.

--- a/src/content/docs/contributors/index.mdx
+++ b/src/content/docs/contributors/index.mdx
@@ -1,0 +1,35 @@
+---
+title: Contributors
+description: Reference for people working on the GAIA template repo itself. Covers surface that does not ship to adopters.
+sidebar:
+  order: 1
+---
+
+This section covers GAIA surface that exists in the template repo but does not ship to adopters. Audience: Steven and any outside contributors working on the GAIA template itself.
+
+If you ran `npx create-gaia my-app` and got a scaffolded project, this section is not for you. Stay in the adopter docs.
+
+## Adopter / contributor split
+
+GAIA distinguishes two audiences and routes its surface accordingly. Two release mechanisms strip contributor-only material from the adopter tarball:
+
+1. **Path-level exclusion**. Entire files and directories listed in `.gaia/release-exclude` never enter the tarball produced by the GitHub Release workflow. Examples: `.claude/commands/gaia-release.md`, `.gaia/cli/src/`, `.gaia/cli/health/`, `wiki/entities/`, `wiki/meta/`.
+2. **Block-level exclusion**. Content between `<!-- gaia:maintainer-only:start -->` and `<!-- gaia:maintainer-only:end -->` markers inside files that DO ship. The shipped file is a subset of the source.
+
+Both pass through the bundle-time scrub during release. The on-disk `.gaia/release-exclude` is the authoritative manifest of path-level rules.
+
+## What's in this section
+
+- [`/gaia-release`](/contributors/release/): audience scope and what releases produce. The detailed runbook is internal to the maintainer.
+- [`/health-audit`](/contributors/health-audit/): autonomous health audit and auto-heal loop with circuit breakers.
+- [CLI surface](/contributors/cli/): `gaia` binary subcommands that contributors invoke directly, plus where their source lives.
+- [CI workflows](/contributors/ci/): `release.yml`, `cli-tests.yml`, `distribution.yml`, `forensics-triage.yml`.
+- [Contributor wiki content](/contributors/wiki/): `wiki/entities/`, `wiki/meta/`, and the `gaia:maintainer-only` block convention.
+
+## Source-of-truth pointers
+
+- `.gaia/release-exclude`: path-level exclusion manifest
+- `gaia/.gaia/cli/src/`: CLI source
+- `gaia/.gaia/cli/health/runbook.md`: health audit runbook
+- `gaia/wiki/entities/`, `gaia/wiki/meta/`: contributor wiki content
+- `gaia/.github/workflows/`: CI workflows (mix of contributor-only and adopter-shipped)

--- a/src/content/docs/contributors/release.mdx
+++ b/src/content/docs/contributors/release.mdx
@@ -1,0 +1,28 @@
+---
+title: Releases
+description: Audience and scope for /gaia-release. The release workflow exists in the template repo but is excluded from the adopter tarball.
+sidebar:
+  order: 2
+---
+
+`/gaia-release` cuts a new release of the GAIA template itself. It is invoked by Steven only. The slash command and its supporting `gaia-maintainer` binary are stripped from the adopter tarball by `.gaia/release-exclude`, so adopters never see this surface.
+
+## Why contributors should know it exists
+
+Contributors who modify CLI source, hooks, rules, or shipped wiki content land in trees that a release will eventually package. The release flow validates those trees in three ways:
+
+- **Manifest regeneration**. `.gaia/manifest.json` lists every file in the adopter tarball with a class (`owned`, `shared`, or `wiki-owned`). The classification rules live in `.gaia/cli/src/release/manifest.ts`. The on-disk manifest is the source of truth that `/update-gaia` consumers read.
+- **Bundle-time scrub**. The release workflow stages a tree from `git ls-files`, subtracts `.gaia/release-exclude` patterns, then runs the scrub against the staging directory. The scrub strips `gaia:maintainer-only` blocks and runs leak checks before the tarball is built.
+- **Distribution test gate**. The release workflow runs `.gaia/tests/distribution/run-all.sh` against an independently-staged tree before the tarball uploads. A broken release halts before `gh release create` runs.
+
+If a change touches surface the release flow validates, expect the next release to surface any drift.
+
+## What runs the release end-to-end
+
+The CI counterpart is [release.yml](/contributors/ci/#releaseyml). It runs on `v*.*.*` tags, re-stages the tree, re-validates the staged tree and verifies runtime dependencies, runs the distribution test gate, builds the tarball, and creates the GitHub Release.
+
+`main` is protected. The release commit lands on a `release/v<version>` branch, goes through a PR, and the tag is created on the merge commit after it lands on `main`.
+
+## Detailed runbook
+
+The end-to-end runbook lives in the template source at `.claude/commands/gaia-release.md`. It is not reproduced here.

--- a/src/content/docs/contributors/wiki.mdx
+++ b/src/content/docs/contributors/wiki.mdx
@@ -1,0 +1,52 @@
+---
+title: Contributor wiki content
+description: wiki/entities and wiki/meta are excluded from the adopter tarball. Contributor-only wiki content and the gaia:maintainer-only block convention.
+sidebar:
+  order: 6
+---
+
+Two directories under `gaia/wiki/` are excluded from the adopter tarball by `.gaia/release-exclude`:
+
+- `wiki/entities/`: named systems, products, and people tracked across the codebase.
+- `wiki/meta/`: process and convention pages about the wiki itself.
+
+Three individual concept and decision pages are also excluded: `wiki/concepts/Release Workflow.md`, `wiki/decisions/Bundle-time Scrub.md`, and `wiki/decisions/Forensics Triage Workflow.md`.
+
+The user-facing wiki workflow (`/gaia wiki sync`, `/gaia wiki consolidate`, `/gaia wiki lint`) lives in adopter docs. This page covers content that contributors maintain on the template repo's own wiki.
+
+## `wiki/entities/`
+
+Pages here describe named entities the GAIA team tracks. Current entries:
+
+- `GAIA.md`: the project itself, including history, naming convention, and supporting links.
+- `Steven Sacks.md`: author and maintainer.
+
+Entity pages use the `entity` type frontmatter with an `entity_type` discriminator (`project`, `person`, etc.).
+
+When to add: a new entity becomes worth tracking on its own page when it gets cross-linked from concept or decision pages and when its identity is useful to disambiguate from other names. Generic concepts go under `wiki/concepts/`, not here.
+
+## `wiki/meta/`
+
+Pages here describe the wiki's own process. The directory currently holds wiki lint reports and consolidate reports dated by run, plus a dashboard. The reports are generated artifacts of `/gaia wiki lint` and `/gaia wiki consolidate` runs.
+
+When to add: a new meta page is appropriate when it documents how the wiki itself works (a new convention, a new dashboard, a new workflow). Generated lint and consolidate reports land here automatically; do not write them by hand.
+
+## `gaia:maintainer-only` block convention
+
+Some pages under `wiki/concepts/`, `wiki/decisions/`, `.claude/`, and `.specify/extensions/gaia/` ship to adopters but contain blocks that do not. The block convention is:
+
+```markdown
+<!-- gaia:maintainer-only:start -->
+This block is contributor-only. It gets stripped from the adopter
+tarball by the bundle-time scrub during release.
+<!-- gaia:maintainer-only:end -->
+```
+
+The shipped file is a subset of the source: the markers and everything between them get removed by the scrub before the tarball builds. The literal phrase is `maintainer-only`; this is the on-disk identifier and matches the comment text in `.gaia/release-exclude` and the step name in `release.yml`. Public-facing references in the docs site use "Contributors."
+
+When to use the block convention rather than path-level exclusion: use blocks when most of a page is adopter-relevant but a section needs to stay internal. Use path-level exclusion (an entry in `.gaia/release-exclude`) when the entire file is contributor-only.
+
+## Cross-references
+
+- Adopter wiki workflow: see the `/gaia wiki` skill family in adopter docs.
+- The `.gaia/release-exclude` manifest is the authoritative path-level exclusion list. Anything matched there is also skipped by `gaia-maintainer release manifest`, so the adopter manifest never references files an adopter cannot have.

--- a/src/content/docs/gaia/audit.mdx
+++ b/src/content/docs/gaia/audit.mdx
@@ -1,0 +1,103 @@
+---
+title: /gaia audit
+description: Audit memory, rules, and wiki for duplication, stale entries, and over-budget auto-loads. Produces a report and applies it.
+---
+
+`/gaia audit` reviews the project's knowledge stores (machine-local memory, project rules, wiki, auto-loaded `CLAUDE.md` files) for duplication, stale entries, and bloated auto-loads. It runs in two stages: a research stage produces a report, then an apply stage executes the report mechanically.
+
+The wiki is the source of truth. Memory is machine-local only. Auto-loaded files carry a token cost on every session, so the audit pushes detail behind lazy wikilinks and keeps the auto-loaded surface as a pointer set.
+
+## When to use it
+
+Run `/gaia audit` periodically: after a stretch of new feature work, when `CLAUDE.md` or `wiki/hot.md` feels heavy, or when the same fact seems to live in two places.
+
+Wiki-internal duplication and broken-link repair are out of scope here. Those belong to `/gaia wiki consolidate` and `/gaia wiki lint`.
+
+## How to invoke
+
+Default. Research, then apply:
+
+```
+/gaia audit
+```
+
+Apply only. Re-execute the most recent report:
+
+```
+/gaia audit --apply
+```
+
+Use `--apply` when an earlier run produced a report but drift caused some actions to skip; fix the drift, then re-apply. Reports older than 24 hours are refused. Generate a fresh one in that case.
+
+## What gets audited
+
+| Store | Path | Auto-loaded? |
+| --- | --- | --- |
+| Machine-local project memory | `~/.claude/projects/<project>/memory/` | `MEMORY.md` (first 200 lines) |
+| Machine-local agent memory | `~/.claude/agent-memory/` | Per-agent, on demand |
+| Project agent memory | `.claude/agent-memory/` | Per-agent, on demand |
+| Project root `CLAUDE.md` | `CLAUDE.md` | Yes, every session |
+| Wiki hot cache | `wiki/hot.md` | Yes, every session |
+| Wiki domain pages | `wiki/<domain>/` | On demand |
+| Project rules | `.claude/rules/*.md` | Yes when `paths:` frontmatter matches |
+| Nested `CLAUDE.md` | `**/CLAUDE.md` (e.g. monorepo packages) | Yes when cwd matches |
+
+The audit checks each entry for cross-store duplication and classifies it as:
+
+- **DUPLICATE**: fact already canonical in the wiki; mark for deletion.
+- **PROMOTE**: durable knowledge only in memory; propose moving to a specific wiki page.
+- **KEEP-LOCAL**: genuinely machine-local (personal preference, machine path, unique dev env); keep as-is.
+- **STALE**: references a file, branch, or feature no longer present; mark for deletion.
+
+Then it computes auto-load budgets:
+
+| File | Budget |
+| --- | --- |
+| `wiki/hot.md` | ≤200 words |
+| `CLAUDE.md` (root) | ≤400 words |
+| Any nested `CLAUDE.md` | ≤400 words |
+| Any single `.claude/rules/*.md` | ≤200 lines |
+
+Anything over budget is flagged with a proposed fix: inline facts moved to the wiki, duplicated sections consolidated, or oversized files split into narrower ones.
+
+## The two-stage flow
+
+**Stage 1: research (Sonnet).** Reads the stores, classifies entries, computes budgets, writes a report at `.gaia/local/audit/KNOWLEDGE-{YYYY-MM-DD-HHMM}.md`. Snapshots `git status --short` and `git rev-parse HEAD` into the report's frontmatter so stage 2 can detect drift. Mutates nothing outside `.gaia/local/audit/`.
+
+**Stage 2: apply (Haiku).** Reads the most recent report. Re-resolves project root, memory dir, and agent memory dir; if they differ from the report's frontmatter, stops with a clear error. Verifies each action's drift signal: SHA-256 of the target file, or a verbatim snippet that must appear in current content. Applies the action verbatim, or skips with a recorded reason. Never improvises.
+
+The split exists for technical reasons (different reasoning loads, drift-check between stages), not as a user-confirmation gate. Calling `/gaia audit` is the intent to apply.
+
+## Action types
+
+| Action | What it does |
+| --- | --- |
+| `delete` | Remove a memory or rules file whose facts are canonical in the wiki, gated on the file's SHA-256 matching what the report saw. |
+| `delete-entry` | Remove a specific block (e.g. a heading section in `MEMORY.md`) by verbatim match. |
+| `promote` | Move durable knowledge from memory to a named wiki page. Performs the target action (`append_section`, `insert_after_heading`, or `create_new`), prepends a log entry to `wiki/log.md`, appends an index entry to `wiki/index.md`, then deletes the source if the action says to. |
+| `replace` | Shrink inline content in an auto-loaded file to a wikilink. The current block must match byte-for-byte; the replacement is typically a single wikilink line. |
+
+Stage 2 applies actions in order: `replace` → `delete-entry` → `promote` → `delete`. Earlier shrinks never reference content that later actions touch; deletes come last so pointers do not go stale before they are used.
+
+## Drift handling
+
+Each action ships with a drift signal: either `expect_sha256` (file-level) or a verbatim `before:` / `expect:` snippet. Stage 2 checks the signal before applying:
+
+- Match: apply, flip the checkbox to `[x]`.
+- Mismatch: skip, flip to `[~]` with reason `sha drift` or `snippet drift`.
+- Error during apply: flip to `[!]` with the error.
+- Target missing: `[!]` with `target missing`.
+
+Files dirty in git that appear as targets get marked `SKIP (dirty)` before any action runs. Dirty-file protection is preventive, not diagnostic.
+
+## After the run
+
+The output is a working-tree diff, not a commit. Stage 2 never runs `git add` or `git commit`. Review the diff and commit if satisfied.
+
+The skill prunes its own report directory: keeps the newest five reports unconditionally, then deletes anything older than 30 days beyond that floor.
+
+## Related
+
+`/gaia audit` is distinct from the `code-review-audit` agent. The agent reviews code changes on a branch before merge for security, performance, and correctness. `/gaia audit` reviews knowledge stores for duplication and bloat. Different inputs, different outputs, different audiences.
+
+For wiki-internal redundancy (multiple wiki pages saying the same thing) and broken wikilinks, use `/gaia wiki consolidate` and `/gaia wiki lint` respectively.

--- a/src/content/docs/gaia/forensics.mdx
+++ b/src/content/docs/gaia/forensics.mdx
@@ -1,0 +1,119 @@
+---
+title: /gaia forensics
+description: Turn a GAIA workflow misfire into a redacted, classified bug report ready to file.
+sidebar:
+  order: 6
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`/gaia forensics` turns a GAIA workflow misfire (a failed `/gaia-init`, a stuck `/update-gaia`, a quality-gate refusal, an unexpected hook block) into a structured, redacted bug report. Read-only end-to-end: it inspects state, never modifies, installs, or remediates.
+
+## When to use it
+
+Run it when something GAIA-related goes wrong and you want to file a useful issue without manually scrubbing paths and tokens out of your logs. Good fit for:
+
+- Init or update workflows that bailed mid-run.
+- Hooks that blocked a commit or tool call you expected to pass.
+- Wiki-sync, scaffold, or quality-gate failures.
+- Dev server problems traced to GAIA configuration.
+
+If the failure is in your own application code, this is the wrong tool. Forensics is scoped to GAIA's own surface.
+
+## Invocation
+
+```
+/gaia forensics [optional one-line description]
+```
+
+With an argument, the description is used verbatim. Without an argument, forensics asks one open-ended clarifying question (`What went wrong? Describe what you were doing, what you expected, and what happened.`) and waits for your reply.
+
+## What it does
+
+Forensics runs in nine read-only steps:
+
+1. **Capture.** Reads a fixed set of state files: GAIA version, Node, pnpm, Claude Code version, branch, dirty status, plus class-specific state files (different per failure category). Bodies from `app/` and `wiki/` are never captured. `.env*` and `node_modules/` are excluded. Long files are truncated.
+2. **Classify.** Walks a fixed taxonomy of eight classes (`init`, `update`, `wiki-sync`, `quality-gate`, `hook`, `scaffold`, `dev-server`, `other`) and matches signal phrases against your description. Cites the matched phrase and named state file as evidence.
+3. **Diagnose.** Decides whether the failure is a user-config issue (wrong Node version, missing env var, dirty working tree blocking a workflow) or a probable bug. User-config wins when both signals fire: the environment is the more likely cause.
+4. **Redact.** Runs the assembled report body through one redaction pass: project-root strip, machine-leak fallback, seven token-pattern sweeps, env-var value scrub, then a sanity recheck. If a credential-shaped string survives the recheck, forensics halts rather than emitting a partially redacted body.
+5. **Render.** Emits a strict-schema report with frontmatter (class, GAIA version, created date, optional issue URL) and four fixed sections: `## Symptom`, `## Classification`, `## Capture`, `## Reproduction context`.
+6. **Save.** Writes to `.gaia/local/forensics/<timestamp>-<class>.md`. The timestamp is ISO-8601 compact UTC.
+7. **Branch on diagnosis.** User-config failures: prints remediation steps inline, exits. Probable bugs: continues to the issue-filing offer.
+8. **Offer to file.** If `gh` is installed, asks once whether to file an issue on `gaia-react/gaia` with the `gaia-forensics` label. If `gh` is not installed, prints the local report path and exits.
+9. **Confirm.** Prints a final line with the report path and (if filed) the issue URL.
+
+## Strict body schema
+
+The report body has fixed section headers and order. Phase-2 automation parses these without LLM fallback, so the schema is load-bearing:
+
+```markdown
+---
+class: <init|update|wiki-sync|quality-gate|hook|scaffold|dev-server|other>
+gaia_version: <semver>
+created: <YYYY-MM-DD>
+gh_issue_url?: <url>
+---
+
+## Symptom
+<one-paragraph user description, redacted>
+
+## Classification
+class: <tag>
+evidence: <verbatim user phrase> + <named state file>
+
+## Capture
+gaia_version: <semver>
+node: <version>
+pnpm: <version>
+claude_code: <version>
+branch: <name>
+dirty: <true|false>
+class_state_files:
+  - <repo-relative path>: <one-line summary>
+
+## Reproduction context
+<plain prose: what you were doing, what you expected, what happened>
+```
+
+The body posted to a GitHub issue is the post-frontmatter portion (`## Symptom` through the end), byte-identical to the local file body.
+
+## Hard constraints
+
+<Aside type="caution">
+These four rules are non-negotiable. They apply to every code path.
+</Aside>
+
+- **Read-only end-to-end.** Forensics inspects state. It never modifies, installs, fetches, or remediates.
+- **Write surface allowlist.** Writes go to one user-visible directory: `.gaia/local/forensics/` for the report. No other path is writable.
+- **Uniform redaction.** The local file body and the GitHub issue body pass through the same single redaction pass. The two bodies are byte-identical post-redaction.
+- **Strict body schema.** Frontmatter fields, section headers, and section order are fixed. Drift breaks downstream triage.
+
+## Example flow
+
+```
+> /gaia forensics quality-gate refused to merge after I bumped a package
+```
+
+Forensics captures state, classifies as `quality-gate`, reads the relevant state files, redacts the body, writes the report:
+
+```
+Report saved: .gaia/local/forensics/20260509T143022Z-quality-gate.md
+
+File a GitHub issue for this report?
+```
+
+If you say yes and `gh` is installed:
+
+```
+Report: .gaia/local/forensics/20260509T143022Z-quality-gate.md | Issue: https://github.com/gaia-react/gaia/issues/342
+```
+
+If you say no, the report stays local and you can attach it to a manual issue later.
+
+## Storage
+
+`.gaia/local/forensics/` is project-local and gitignored. Reports stay on your machine unless you explicitly file them. Old reports are not pruned automatically.
+
+## Related
+
+- [/gaia](/gaia/): router overview.

--- a/src/content/docs/gaia/handoff-pickup.mdx
+++ b/src/content/docs/gaia/handoff-pickup.mdx
@@ -1,0 +1,113 @@
+---
+title: /gaia handoff and /gaia pickup
+description: Pause a session and resume cold without re-reading the conversation.
+sidebar:
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`/gaia handoff` writes a self-contained handoff document so a future session can pick up cold. `/gaia pickup` reads the most recent handoff and reconstitutes context. They are paired: one closes a session, the other opens the next one.
+
+## When to use them
+
+Reach for `/gaia handoff` at the end of a working session, before a context break, or when state is non-obvious (in-flight feature, dirty tree, background process still running). Reach for `/gaia pickup` at the start of any session where the previous session ended with a handoff, or when switching to a new machine.
+
+The two commands are decoupled. A handoff written on one machine, in one Claude Code session, is consumed by `/gaia pickup` in any later session on any machine that has the same project checked out.
+
+## /gaia handoff
+
+```
+/gaia handoff [optional inline notes]
+```
+
+Pulls from three sources:
+
+- The conversation transcript (accomplishments, decisions, gaps, open questions).
+- Git state (`git rev-parse --abbrev-ref HEAD`, `git log -1 --oneline`, `git status --short`).
+- Any inline notes you pass after `handoff`.
+
+The handoff document is written to:
+
+```
+.gaia/local/handoff/HANDOFF-{YYYY-MM-DD}-{slug}.md
+```
+
+The slug is derived from the session's main thread (e.g. `auth-refactor`, `route-cleanup`).
+
+### What the document contains
+
+Sections present only when there is real content. Empty sections are dropped, not stubbed.
+
+- **Accomplishments**: what shipped, with commit hashes when committed.
+- **Decisions**: table of decision, rationale, impact.
+- **Gaps and open questions**: each gap names a status (`FIXED` / `PARTIAL` / `UNKNOWN` / `DEFERRED` / `INTENTIONAL`), notes, a concrete next check, and a reference (`@path/to/file:line`).
+- **Environment state**: branch, background processes, devices or simulators, test fixtures.
+- **Reference files**: `@path` cross-references so the next session can jump straight in.
+- **Next actions**: table of concrete, testable steps with rough effort estimates.
+
+### Discipline
+
+The handoff is a synthesis, not a transcript dump. Every "Next Action" must be executable without context. Every "Gap" must name a file and a diagnostic. Commit hashes, file paths, and device IDs are never fabricated; if uncertain, they are omitted.
+
+## /gaia pickup
+
+```
+/gaia pickup
+```
+
+No arguments. Pickup runs through four steps:
+
+1. **Locate.** Find the most recent handoff: `ls -t .gaia/local/handoff/HANDOFF-*.md | head -1`. If no handoff exists, fall back to `wiki/hot.md` and report `No handoff found — resuming from hot cache.`
+2. **Read.** Load the handoff in full. Run `git rev-parse --abbrev-ref HEAD`, `git status --short`, and `git log -1 --oneline` in parallel.
+3. **Report.** Surface a tight status block: current branch (with drift from the handoff if any), handoff filename and date, one-line context, 1 to 3 bullets on what's done or in-flight, 1 to 3 bullets on gaps, and a suggested next action.
+4. **Archive.** After you confirm a direction (pick an action, start editing, or say "go"), the consumed handoff moves to `.gaia/local/handoff/archive/`.
+
+<Aside type="note">
+The handoff archive only happens after you act on it. Premature archive would lose context if the pickup itself hits a context break.
+</Aside>
+
+### Drift detection
+
+If the handoff says branch `feat/auth` at commit `abc1234`, and current state is `main` at `def5678` with a dirty tree, pickup flags the divergence before suggesting next actions. The handoff may be stale; pickup says so explicitly rather than reconstructing context against a different reality.
+
+## Example flow
+
+End of Tuesday session:
+
+```
+> /gaia handoff coach voice prompts still need fixture audit
+```
+
+Wednesday morning, fresh session:
+
+```
+> /gaia pickup
+```
+
+Pickup reports:
+
+```
+Branch: feat/coach-voice (clean, matches handoff)
+Last handoff: HANDOFF-2026-05-08-coach-voice.md (2026-05-08)
+Context: Wired coach voice prompts to /api/coach; fixtures pending.
+
+State:
+- Coach prompt template extracted to lib/prompts/coach.ts
+- Endpoint contract aligned with spec
+
+Open:
+- Fixtures audit: voice cues for happy/sad/neutral are stubs
+- Test for empty transcript edge case
+
+Suggested next: Audit fixture coverage at @lib/prompts/coach.fixtures.ts:1
+```
+
+## Storage
+
+Handoffs are project-local: `.gaia/local/` is gitignored. They never enter version control, so private notes, dirty-tree details, and device IDs stay on the machine that wrote them. Archived handoffs are not pruned automatically; clean `.gaia/local/handoff/archive/` when it grows.
+
+## Related
+
+- [/gaia plan](/gaia/plan/): multi-step orchestration. Pairs naturally with handoff for long-running plans that span sessions.
+- [/gaia](/gaia/): router overview.

--- a/src/content/docs/gaia/index.mdx
+++ b/src/content/docs/gaia/index.mdx
@@ -1,0 +1,39 @@
+---
+title: /gaia router
+description: Sub-routes available under /gaia for day-to-day GAIA workflows.
+sidebar:
+  order: 1
+---
+
+`/gaia` is the entry point for GAIA's day-to-day workflows. It is a router skill: the first whitespace-separated token of the invocation selects a sub-route, and the rest of the input is forwarded to that sub-route.
+
+The skill itself lives at `.claude/skills/gaia/SKILL.md`. Each sub-route's instructions live at `.claude/skills/gaia/references/<sub>.md`.
+
+## Sub-routes
+
+| Sub-route | What it does |
+| --- | --- |
+| [`/gaia plan`](/gaia/plan/) | Plan a feature using task orchestration. Produces a plan directory with task docs, an orchestrator runbook, and a kickoff prompt for a fresh session. |
+| [`/gaia spec`](/gaia/spec/) | Run a Socratic discovery loop and save an immutable SPEC artifact. Optionally chains into `/gaia plan`. |
+| [`/gaia audit`](/gaia/audit/) | Audit memory, rules, and wiki for duplication, stale entries, and over-budget auto-loads. Produces a report and applies it. |
+| [`/gaia handoff`](/gaia/handoff-pickup/) | Generate a session handoff document so context can transfer to a fresh session. |
+| [`/gaia pickup`](/gaia/handoff-pickup/) | Restore context from the most recent handoff. |
+| [`/gaia forensics`](/gaia/forensics/) | Capture a redacted, classified bug report from a surfaced issue. |
+| [`/gaia wiki`](/gaia/wiki/) | Wiki maintenance. With no sub-arg, runs the full chain: `sync`, then `consolidate`, then `lint`. Each can also be invoked individually. |
+
+## Help text
+
+Invoking `/gaia` with no argument (or with an unrecognized one) prints the help message:
+
+```
+Usage: /gaia <subcommand> [args]
+
+  plan [description]               Plan a feature using task orchestration
+  spec [description]               Socratic discovery to author an immutable SPEC artifact
+  spec auto [description]          Non-interactive: agent answers Socratic questions, mirrors to GitHub issue, chains to /gaia plan
+  handoff [notes]                  Generate a session handoff document
+  pickup                           Restore context from the most recent handoff
+  audit [--apply]                  Audit memory + wiki and apply changes (--apply: re-apply existing report only)
+  forensics [description]          Capture a redacted, classified, file-able bug report
+  wiki [sync|consolidate|lint]     Wiki maintenance (full chain if no sub-arg)
+```

--- a/src/content/docs/gaia/plan.mdx
+++ b/src/content/docs/gaia/plan.mdx
@@ -1,0 +1,103 @@
+---
+title: /gaia plan
+description: Plan a feature using task orchestration. Produces a plan directory and a kickoff prompt for a fresh orchestrator session.
+---
+
+Plan a complex feature by decomposing it into parallel workstreams with frozen interface contracts. `/gaia plan` does not implement anything. It produces a plan directory, then hands you a single copy-paste prompt to launch a fresh orchestrator session that executes the plan.
+
+## When to use it
+
+Reach for `/gaia plan` when the work spans multiple files or modules, has identifiable parallel slices (UI plus service layer plus tests, or backend plus frontend plus migration), or benefits from isolating each slice in its own subagent context.
+
+For one-line bug fixes or single-file edits, skip the planning ceremony and just edit.
+
+For feature work that has not been clarified yet, run [`/gaia spec`](/gaia/spec/) first. It chains into `/gaia plan` after save.
+
+## How to invoke
+
+```
+/gaia plan a feature description in plain English
+```
+
+Or, with a SPEC reference (typically passed automatically by `/gaia spec`):
+
+```
+/gaia plan SPEC-005: rework auth, see /abs/path/.gaia/local/specs/SPEC-005.md
+```
+
+If you invoke `/gaia plan` with no description, it asks for one before continuing.
+
+## What gets produced
+
+`/gaia plan` writes a plan directory at:
+
+```
+.gaia/local/plans/<kebab-slug>/
+```
+
+The slug derives from the description. When invoked from a SPEC, the slug is prefixed with the SPEC id (e.g. `spec-005-cards-layout`) so plan-to-SPEC discovery is a one-line `ls .gaia/local/plans/ | grep ^spec-005-`. Slug collisions append `-2`, `-3`, and so on, so parallel invocations coexist without overwriting each other.
+
+Inside the directory:
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | Task graph: phase order, which tasks run in parallel within each phase, and the frozen interface contracts shared across tasks. References the source SPEC if there was one. |
+| `ORCHESTRATOR.md` | Runbook for the orchestrator session that executes the plan. Branch policy, phase order with quality gates, sub-agent prompt templates, pre-merge audit obligation, git flow, stop conditions. |
+| `KICKOFF.md` | The exact prompt a fresh Claude Code session reads to start orchestrating. Self-contained, no assumed context. |
+| `task-<name>.md` | One per parallel workstream. Self-contained for a fresh-context sub-agent. Includes interface contracts, files to touch (with line-range hints), acceptance criteria, and dependencies on other tasks. |
+| `SUMMARY.md` | Created and maintained by the orchestrator during execution. Append-only ledger of phase commits and sub-agent findings. |
+
+## The flow
+
+1. **Description capture.** If `$ARGUMENTS` is empty, the skill asks. If a SPEC reference is detected, the SPEC itself becomes the source of truth and the dispatch summary is just a label.
+2. **Model check.** If the current session is not on Opus, the skill offers to spawn the planning agent on Opus 4.7. Plans benefit from the higher-capacity model.
+3. **Plan directory resolution.** Slug is derived (or seeded from the SPEC id), suffixed on collision, then created under `.gaia/local/plans/`.
+4. **Planner dispatch.** The skill spawns a `general-purpose` Agent restricted to writing inside the plan directory only. The planner reads `wiki/concepts/Task Orchestration.md` for the orchestration pattern, then writes the plan files directly to disk.
+5. **Verification.** The skill confirms `README.md`, `ORCHESTRATOR.md`, `KICKOFF.md`, and at least one `task-*.md` exist. If anything is missing, the failure surfaces; no silent retry.
+6. **Hand-off.** The skill prints the kickoff prompt as a fenced code block and tries to copy it to the system clipboard via `pbcopy`, `wl-copy`, `xclip`, `xsel`, `clip.exe`, or `clip` (whichever is available). The trailing line says whether the copy succeeded.
+
+The kickoff prompt looks exactly like:
+
+```
+Read /abs/path/.gaia/local/plans/<slug>/KICKOFF.md and execute it.
+```
+
+Paste it into a fresh Claude Code session, started cold, to run the plan. The orchestrator's behavior lives entirely in `KICKOFF.md`.
+
+## Orchestrator vs sub-agents
+
+The orchestrator owns coordination. It runs in your active Claude Code session after you paste the kickoff prompt. It commits, pushes, opens the PR, runs quality gates between phases, dispatches sub-agents, and never edits source files itself.
+
+Sub-agents own implementation. The orchestrator dispatches one per task per phase with a fresh-context prompt. Each sub-agent edits files, then returns a structured summary that ends with a `## Notes for orchestrator` section (findings, deviations from plan, follow-ups for after merge). Sub-agents never commit, push, or touch git.
+
+The orchestrator merges sub-agent notes into `SUMMARY.md` after every phase, so context survives compression.
+
+## Pre-merge audit
+
+Before any `gh pr merge` invocation, the orchestrator spawns the `code-review-audit` agent against the current branch. If the audit reports critical or unresolved important issues, the orchestrator stops and surfaces them. A clean pass writes a marker that a deny-hook reads to gate `gh pr merge`. The orchestrator does not wait for the deny-hook to fire; it spawns the agent proactively.
+
+## Branch policy
+
+If the orchestrator starts on `main` or `master`, it asks how to isolate the work: a feature branch in place (recommended) or a linked git worktree (experimental). On any other branch, it assumes the current branch is the work branch and proceeds.
+
+## Stop conditions
+
+The orchestrator stops on any sub-agent failure or quality-gate failure. It surfaces the failure, appends it to `SUMMARY.md` under a `(HALTED)` block, and waits for human direction. It does not "fix and continue."
+
+Quality gates between phases run `pnpm typecheck && pnpm lint`. A non-zero exit halts the run before the next phase dispatches.
+
+## Final summary and self-cleanup
+
+After all implementation phases pass and the final commit is pushed, the orchestrator reads `SUMMARY.md` and prints a brief summary to the user: phases completed, sub-agents run, files touched, commits pushed (count plus short SHAs), PR URL, quality-gate status, and the highest-signal findings or deviations or follow-ups drawn from the ledger.
+
+After the user confirms the PR is ready to merge, the orchestrator deletes its own plan folder. If `.gaia/local/plans/` is gitignored (the GAIA default), the deletion is invisible to git and skipped from commit. Otherwise, the deletion lands as the final commit on the PR.
+
+## Worktree mode
+
+If the orchestrator chose worktree mode at branch policy, the post-merge phase confirms the merge via `gh pr view <N> --json state`, then calls `ExitWorktree({action: "remove", discard_changes: true})`. The merged-state confirmation is the primary signal that the work is preserved; `discard_changes: true` is correct because squash-merge produces unreachable commits on the worktree branch.
+
+If the orchestrator was itself dispatched into an isolated subagent context, it cannot call `ExitWorktree` directly. It instead emits a copy-paste continuation prompt naming the absolute worktree path and the merged-state details, then stops. The user pastes that prompt into a fresh top-level session to complete the cleanup.
+
+## Related
+
+- [`/gaia spec`](/gaia/spec/) is the upstream of `/gaia plan`. The chain-trigger after spec save dispatches `/gaia plan` automatically when accepted.

--- a/src/content/docs/gaia/spec.mdx
+++ b/src/content/docs/gaia/spec.mdx
@@ -1,0 +1,103 @@
+---
+title: /gaia spec
+description: Run a Socratic discovery loop and save an immutable SPEC artifact. Optionally chains into /gaia plan.
+---
+
+`/gaia spec` produces an immutable SPEC artifact through a guided Socratic conversation. The artifact lands at `.gaia/local/specs/SPEC-NNN.md` and serves as the contract for [`/gaia plan`](/gaia/plan/) to decompose into work. The skill produces an artifact and stops. It does not implement anything.
+
+The flow runs on top of [spec-kit](https://github.com/github/spec-kit), with GAIA-specific shape and discipline layered through a registered preset and extension.
+
+## When to use it
+
+Run `/gaia spec` for any feature where the boundaries are not yet clear. It is the right entry point when the description has more questions than answers, or when multiple readings of the same prompt produce different intents.
+
+For changes whose intent is already obvious (a bug fix, a refactor against a known interface, a copy edit), skip directly to [`/gaia plan`](/gaia/plan/).
+
+## How to invoke
+
+Interactive (most common):
+
+```
+/gaia spec a feature description
+```
+
+Auto. Non-interactive: the agent answers all Socratic questions itself, mirrors to a GitHub issue, and chains to `/gaia plan`:
+
+```
+/gaia spec auto a feature description
+```
+
+A description is required in auto mode. Without one, the skill aborts immediately.
+
+## Two-gate ceremony
+
+The SPEC has two gates and they are non-negotiable.
+
+**Gate 1: shape confirmation.** Before any clarifying question fires, the skill presents the proposed `intent` paragraph and the proposed UATs in plain English. The user reads, confirms, or revises. On confirmation, the gate-1 shape is snapshotted to `.gaia/local/cache/gate1-<spec_id>.json` and treated as immutable for the remainder of the session. The self-review at gate 2 detects drift against this snapshot.
+
+**Gate 2: artifact confirmation.** After the Socratic loop and self-review apply, the full rendered SPEC is presented to the user one last time. Revisions loop until the user confirms. Only then does the canonical save fire.
+
+Once saved, the SPEC artifact is immutable. Mutations require an explicit reopen ceremony with `## Reopen rationale` and `## UAT diff` sections, which the lint helper enforces.
+
+## Operational primitives
+
+A handful of mechanics are used by multiple steps:
+
+- **Working-draft cache.** Every fold in the Socratic loop, every gate confirmation, every research result, every self-review apply persists the in-flight draft to `.gaia/local/cache/draft-<spec_id>.md`. A single `Write` per turn. No incremental `Edit` calls. Step 8's canonical save deletes the cache as its final action. Resumed sessions pick up the cache if it is newer than the canonical artifact.
+- **Per-topic revisit counter.** Tracks how many times the user has chosen "push deeper" on a given topic. On the third revisit, the prompt swaps to settle, defer, or push deeper anyway. Prevents one topic from consuming the whole session.
+- **Five-question cap.** Spec-kit's `/clarify` primitive caps the loop at five total questions per session. The wrapper inherits this cap and never invokes `/clarify` twice to extend it.
+- **Discuss-this escape.** Any closed-set question can drop into a plain Q&A discussion. On settlement, the outcome folds into `clarifications.answered[]` and the structured loop resumes on the next topic.
+- **Save partial and resume later.** Every closed-set question offers this escape. It writes the draft cache and exits. Re-invoking `/gaia spec` resumes from the right step.
+
+## The flow
+
+1. **Description capture.** Open-ended prompt if not provided as arguments.
+2. **GitHub issue mirror prompt.** Single `AskUserQuestion`: skip (recommended) or mirror to a GitHub issue on save.
+3. **Resume-vs-start-new.** If an in-progress SPEC exists, the skill surfaces it (last touched, intent first line, UAT count) and asks: resume, start new, or discard the draft cache.
+4. **Initial draft.** `/speckit-specify` runs the GAIA preset's body, allocates a SPEC id, lands the artifact at `.gaia/local/specs/SPEC-NNN.md`. The `before_specify` hook (constitution check) fires automatically.
+5. **Gate 1.** Plain prompt: confirm intent and UATs, or revise.
+6. **Socratic clarify loop.** `/speckit-clarify` runs, capped at five questions. Closed-set questions go through `AskUserQuestion` with the recommended option first; open-ended questions are plain prompts. Per-topic exhaustion checkpoints fire when the natural well runs dry. Research subagents dispatch for any question requiring prior-art lookup.
+7. **Self-review.** The `after_clarify` hook fires `/speckit-gaia-self-review` against the gate-1 snapshot. Findings come back classified low, medium, or high. Low and medium auto-apply; high surfaces to the user before applying. Pending clarifications block save until answered or deferred with rationale.
+8. **Gate 2.** Plain prompt: confirm the full rendered artifact, or revise.
+9. **Canonical save.** Writes `.gaia/local/specs/SPEC-NNN.md` and deletes the working-draft cache. The `after_specify` hook fires `/speckit-gaia-lint` for immutability checks. Cycles 1 and 2 surface failures; cycle 3 prompts to step back to gate 2, defer remaining findings, or push another fix.
+10. **Optional GitHub issue mirror.** If opted in at step 2, `gh-mirror.sh` creates the issue and stamps the URL into frontmatter. Skips silently when `gh` is not authenticated, Issues are disabled, or the viewer lacks write permission.
+11. **Chain to `/gaia plan`.** `AskUserQuestion`: trigger `/gaia plan` now or defer. On yes, the skill enters a multi-plan dispatch loop. Each plan runs in its own `general-purpose` Agent so the wrapper context stays bounded across plan count.
+
+## Auto mode
+
+`/gaia spec auto <description>` produces a SPEC end-to-end without prompts:
+
+- Both gates auto-confirm via internal self-check.
+- Closed-set Socratic questions auto-pick the recommended option.
+- Open-ended questions get the agent's best-judgment answer.
+- Per-topic exhaustion auto-advances; the third-revisit prompt auto-settles.
+- Pending clarifications auto-defer with a static auto-mode rationale.
+- The GitHub issue mirror is forced on.
+- The chain to `/gaia plan` is automatic and produces exactly one plan covering the full SPEC.
+
+Use auto mode when the description is well-formed and the cost of stopping for clarifications outweighs the cost of a reviewer auditing the deferred items afterward.
+
+## Constraints during a spec session
+
+- **Write-surface allowlist.** Every write lands in `.gaia/local/specs/`, `.specify/`, or `.gaia/local/cache/`. No source files, no repo configs.
+- **No machine-local memory for project decisions.** Project-relevant decisions belong only in the SPEC artifact, the wiki, or `.claude/rules/`. Personal preferences (tone, formatting) remain allowed in machine-local memory.
+
+## How spec-kit fires GAIA hooks
+
+Spec-kit's hooks are not shell scripts. When core invokes `/speckit-specify` (or any other core skill), it reads `.specify/extensions.yml` for the relevant event and emits an `EXECUTE_COMMAND: <id>` markdown directive into the agent's reasoning context. The agent then invokes the rendered slash command as a normal Claude skill.
+
+Five GAIA hooks fire across the SPEC lifecycle. Adopters never invoke them by hand.
+
+| Event | Slash command | What it does |
+| --- | --- | --- |
+| `before_specify` | `/speckit-gaia-constitution-check` | Verifies `.specify/memory/constitution.md` is populated and the spec-kit version matches the pin. Blocks if either fails. |
+| `after_clarify` | `/speckit-gaia-self-review` | Audits the in-progress draft for placeholders, scope drift against gate 1, internal inconsistency, ambiguous UATs, and pending clarifications. |
+| `after_specify` | `/speckit-gaia-lint` | Immutability lint on the saved SPEC: required frontmatter keys, frozen `uat_id` per UAT, no placeholder text. |
+| `before_implement` | `/speckit-gaia-uat-write` | Renders frozen UATs into Playwright e2e specs at `.playwright/e2e/<spec-dir>/`, leaving a red-state harness before implementation begins. |
+| `after_implement` | `/speckit-gaia-wiki-promote` | Promotes merged-PR content into the project wiki under `wiki/<subdomain>/`. Defers if the implementing PR has not merged yet. |
+
+The chain-trigger to `/gaia plan` lives inline at step 11 of the flow, not as a hook. Disposition of the SPEC artifact (archive, delete, keep) happens through `/gaia spec close <SPEC-NNN>` after the implementing PR merges.
+
+## Related
+
+After save, [`/gaia plan`](/gaia/plan/) is the natural next step. The chain-trigger at step 11 dispatches it automatically when accepted.

--- a/src/content/docs/gaia/wiki.mdx
+++ b/src/content/docs/gaia/wiki.mdx
@@ -1,0 +1,91 @@
+---
+title: /gaia wiki
+description: Maintain the project wiki. Sync, consolidate, and lint.
+sidebar:
+  order: 7
+---
+
+`/gaia wiki` is the wiki-maintenance router. The wiki at `wiki/` exists for Claude, not for human reading. Its job is to keep a current, structured project context Claude can read on demand instead of re-inferring the same facts from source code on every request. That re-inference is the token sink the wiki eliminates.
+
+## Why the wiki exists
+
+Without it, every session that needs to reason about a service, a hook contract, or a past architectural decision pays for it twice: once when the source was written, again when Claude reads the source to answer a question. The wiki captures the load-bearing facts once and stays current as commits land. Claude reads the wiki, not the source, for orientation.
+
+Adopters interact with the wiki through `/gaia wiki` (sync, consolidate, lint). The contents are not meant to be browsed or hand-edited.
+
+## Sub-commands
+
+```
+/gaia wiki [sync|consolidate|lint]
+```
+
+| Argument | Behavior |
+| --- | --- |
+| `sync` | Evaluate commits since the last sync. Update wiki pages where warranted. No chaining. |
+| `consolidate` | Cross-page redundancy and contradiction audit. Surfaces findings with action prompts. No chaining. |
+| `lint` | Health check: orphans, dead links, drift severity, narrative-reference scrub. No chaining. |
+| (no argument) | Full chain: sync, then consolidate if the gate trips, then lint. |
+
+## /gaia wiki sync
+
+Walks every commit between the wiki's last evaluated SHA and HEAD. For each commit, decides whether the wiki needs an update. Edits pages, logs decisions, advances state.
+
+The classifier runs in two passes. The first pass classifies commits as `WORTHY` or `SKIP` deterministically (subject patterns, file patterns, file count). The second pass reads the diff for `WORTHY` commits only and edits the affected wiki pages.
+
+State lives in `wiki/.state.json`:
+
+- `last_evaluated_sha`: the commit sync most recently classified up to.
+- `last_evaluated_at`: when that classification ran.
+- `last_consolidated_sha`: owned by consolidate. Sync preserves it.
+
+If drift exceeds 30 commits, sync asks before processing the full range. You can opt to sync the recent 20 only and re-anchor.
+
+Sync ends with a one-line trigger: `CONSOLIDATE_TRIGGERED: true|false`. Used by the full-chain mode to decide whether consolidate runs next.
+
+## /gaia wiki consolidate
+
+Detects redundancy and contradiction across the wiki. Four passes:
+
+- **Same-subject across SPECs.** Pairs of pages in the same domain with matching titles or matching provenance gaps. The newer page is canonical; the older becomes a supersession candidate.
+- **Reversed decisions.** Decision pages whose body negates an older decision page (`replaces`, `supersedes`, `deprecated in favor of`, etc.). The older page is flagged for retirement.
+- **Near-collision slugs.** Pairs within Levenshtein distance 2, or where one slug is a prefix of the other.
+- **Subject-orphaned pages.** Pages with zero inbound wikilinks, no body-title matches in `wiki/concepts/` or `wiki/modules/`, and no edits in 90 days.
+
+For each finding, consolidate prompts you per finding: `Apply`, `Keep both`, or `Skip`. `Apply` performs the merge or retire action. `Keep both` writes a `consolidation_ack` flag on the canonical page so the finding does not re-surface. `Skip` defers to the next run.
+
+Consolidate does not commit. Applied edits stage; sync (or your manual commit) lands them. The `wiki-commit-nudge` hook prompts a sync commit after your next `git commit`.
+
+## /gaia wiki lint
+
+Health check. Wraps the upstream `claude-obsidian:wiki-lint` skill and appends three GAIA-specific checks:
+
+- **#11 Wiki drift check.** Reports how many commits behind HEAD the wiki is. Severity: `none`, `low`, `medium`, `high`. High severity surfaces with a `WIKI DRIFT:` prefix.
+- **#12 Dead repo-relative paths.** Backticked paths in wiki body prose that no longer exist on disk (e.g. a hook removed in a refactor still cited in a concept page).
+- **#13 UAT/SPEC narrative-ref drift.** Narrative `UAT-NNN` and concrete `SPEC-NNN` references that should not appear in instruction files. Filters structural matches (template examples, CLI flags, code literals) from narrative ones (section headers, prose).
+
+Reports land at `wiki/meta/lint-report-YYYY-MM-DD.md`. The `wiki/meta/` directory is created locally on first lint run.
+
+## Full chain (no argument)
+
+```
+/gaia wiki
+```
+
+Runs sync. Reads the `CONSOLIDATE_TRIGGERED` line from sync's summary. If true, runs consolidate. Then runs lint.
+
+The order matters: consolidate may move, rename, or archive pages, so lint runs last to check the true post-state. If sync exits on the re-anchor path or a partial-sync interruption, the chain stops; the wiki is in a known-incomplete state and consolidate against an unreachable past makes no sense.
+
+## Hooks that read state
+
+Three hooks consume `wiki/.state.json` in read-only mode:
+
+- `wiki-drift-check`: surfaces drift severity on your first prompt of each session.
+- `wiki-commit-nudge`: suggests a sync after commits that look wiki-relevant.
+- `wiki-session-stop`: checks for uncommitted wiki changes and whether sync state advanced, then prompts accordingly.
+
+These never write the state file. Only sync and consolidate do.
+
+## Related
+
+- [/gaia](/gaia/): router overview.
+- [/gaia plan](/gaia/plan/): multi-step orchestration. Large plans typically end with a wiki sync.

--- a/src/content/docs/getting-started/gaia-init.mdx
+++ b/src/content/docs/getting-started/gaia-init.mdx
@@ -1,0 +1,167 @@
+---
+title: /gaia-init
+description: Initialize a new project from the GAIA template.
+sidebar:
+  order: 2
+---
+
+`/gaia-init` is the first thing you run after `npx create-gaia`. It renames the project to your title, configures language support, replaces template branding, registers Claude tools and plugins, refreshes the wiki, and hands you a project that compiles, lints, and tests cleanly.
+
+`create-gaia` launches Claude Code into the new directory and runs `/gaia-init` automatically. This page documents the flow so you know what to expect.
+
+## When to use this
+
+- Right after `npx create-gaia my-app`, on the maintainer's machine. One-shot for the project's lifetime.
+- Not for clones or new machines. Other developers who clone the project run [`/setup-gaia`](/getting-started/setup-gaia/) instead.
+
+`/gaia-init` runs in whatever language you've been typing in. Source files, rules, skills, and wiki entries stay in English regardless. Only the prompts shown back to you are translated.
+
+## The flow
+
+### 1. pnpm + dependencies
+
+GAIA pins `pnpm@10.33.0` in `package.json` via the `packageManager` field. The command:
+
+1. Enables pnpm via Corepack if available, otherwise installs it globally with npm.
+2. Runs `pnpm install` against the freshly extracted scaffold.
+3. Runs `/update-deps` to pull every dependency to its latest compatible version. If a package is held back, the reason is surfaced.
+
+If install fails, the run halts with the underlying error. Address the cause and re-run `/gaia-init`.
+
+### 2. Project questions
+
+Three sets of prompts.
+
+**Languages.** Pick the primary UI language, then any additional locales. If the project is single-language, you also choose whether to keep the i18n scaffolding wired up. Stripping i18n now is cheaper than removing it later, but adding it back later is harder than leaving it in place.
+
+**Identity.** GitHub username for `CODEOWNERS`, project title (default: `GAIA React App`), and a kebab-case slug derived from the title.
+
+**Statusline mode.** `global` writes the statusline command to `~/.claude/settings.json`, `project` writes to `.claude/settings.json` only, `skip` leaves your settings alone.
+
+### 3. Deterministic init steps
+
+The CLI runs four idempotent subcommands, recording state in `.gaia/init-state.json`:
+
+```bash
+.gaia/cli/gaia init strip-branding --title "<Project Title>"
+.gaia/cli/gaia init configure-i18n --locales "<comma-separated list>" --strip <true|false>
+.gaia/cli/gaia init rename --title "<Project Title>" --kebab "<kebab-slug>"
+.gaia/cli/gaia init wire-statusline --mode <global|project|skip>
+```
+
+If any subcommand exits non-zero, the structured error is printed to stderr and the run halts. After fixing the cause, re-run `/gaia-init` or invoke `.gaia/cli/gaia init resume` directly. Completed steps are detected and skipped.
+
+### 4. Locale scaffolding
+
+If multiple locales were chosen, `/gaia-init` walks each non-`en` locale through the shipped instruction at `.claude/instructions/add-locale.md`. RTL languages (`ar`, `he`, `fa`, `ur`) get the right-to-left flag wired up.
+
+If the project is single-language with i18n stripped, `/gaia-init` follows `.claude/instructions/remove-i18n.md` to remove the framework cleanly.
+
+### 5. Logo and CODEOWNERS
+
+- Replace `app/assets/images/gaia-logo.svg` with your own logo SVG. Storybook brand surfaces import this file directly, so no further wiring is needed.
+- `.github/CODEOWNERS` is overwritten with a single line: `* @<your-github-username>`.
+
+### 6. Environment file
+
+If `.env` does not exist, `.env.example` is renamed to `.env`. If `.env` already exists, it stays as is.
+
+### 7. Verify the build
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test:ci && pnpm build
+```
+
+The chain halts on the first failure. Fix any issues before continuing.
+
+### 8. Claude tooling
+
+`/gaia-init` configures three external tools and three Claude plugins.
+
+**Tools.** Per-machine, not tracked in the repo:
+
+- [React Doctor](https://github.com/millionco/react-doctor): `curl -fsSL https://react.doctor/install-skill.sh | bash`. Installs the `react-doctor` skill to `~/.claude/skills/`. Auto-runs after code edits in a `CLAUDECODE` environment and is invoked by the `code-review-audit` agent pre-merge.
+- [Playwright CLI](https://github.com/microsoft/playwright-cli) binary: `npm install -g @playwright/cli@latest`. Backs the bundled `playwright-cli` skill, which shells out to this binary.
+- [Serena](https://github.com/oraios/serena) MCP server, registered globally for your Claude Code:
+
+  ```bash
+  claude mcp add serena -s user -- uvx --from git+https://github.com/oraios/serena@v1.2.0 serena start-mcp-server --open-web-dashboard false
+  ```
+
+  Serena needs `uv` (Astral's Python toolchain runner). If `uv` is missing, `/gaia-init` installs it first via `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+
+**Plugins.**
+
+```bash
+claude plugin install typescript-lsp@claude-plugins-official
+claude plugin marketplace add AgriciDaniel/claude-obsidian
+claude plugin install claude-obsidian@claude-obsidian-marketplace
+```
+
+**Spec-kit.** Initialized with the GAIA extension and preset registered:
+
+```bash
+SPECKIT_PIN="v0.8.5"
+uvx --from "git+https://github.com/github/spec-kit.git@${SPECKIT_PIN}" specify init --here --ai claude --force
+yes | uvx --from "git+https://github.com/github/spec-kit.git@${SPECKIT_PIN}" specify extension add --dev .specify/extensions/gaia
+yes | uvx --from "git+https://github.com/github/spec-kit.git@${SPECKIT_PIN}" specify preset add --dev .specify/presets/gaia
+```
+
+The pin value `v0.8.5` matches the floor declared in `.specify/extensions/gaia/extension.yml` (`>=0.8.5,<0.10.0`). The command pins explicitly so SPEC authoring proceeds against a known spec-kit version. After this step, `/gaia spec` and the `speckit.gaia.*` commands light up after a Claude restart.
+
+**CI integrations.** Two GitHub Actions workflows ship with GAIA:
+
+- `.github/workflows/code-review-audit.yml`: pre-merge gate that runs the `code-review-audit` agent against every PR.
+- `.github/workflows/forensics-triage.yml`: autonomous triage for issues labeled `gaia-forensics`.
+
+Both invoke Claude via `claude-code-action` and require the `CLAUDE_CODE_OAUTH_TOKEN` repo secret. `/gaia-init` asks whether to enable now or skip.
+
+- **Enable now**: prints copy-pasteable `gh` recipes you run yourself with maintainer credentials (mint the OAuth token via `claude setup-token`, store as a repo secret, mark `code-review-audit` as a required check on `main`). Ensures the `gaia-forensics` issue label exists if the project already has a GitHub remote.
+- **Skip**: moves both workflow files to `.gaia/templates/workflows/`. Copy them back to `.github/workflows/` whenever you decide to enable. `/update-gaia` reads `.gaia/manifest.json` and respects the deletion as adopter intent, so the opt-out persists across updates.
+
+**Statusline executable bit.** `chmod +x .gaia/statusline/*.sh`. Idempotent.
+
+### 9. Optional adaptation feature
+
+You're offered an opt-in to an optional adaptation feature. The default is "Not now"; you can enable it later. Pick whichever you prefer; init proceeds regardless.
+
+### 10. Wiki refresh
+
+The template ships with a wiki shaped for the upstream GAIA project. `/gaia-init` overwrites two files so your project starts with a clean context:
+
+- `wiki/hot.md`: replaced with an empty hot cache.
+- `wiki/log.md`: replaced with a single `/gaia-init | project initialized` entry.
+
+Everything else under `wiki/` stays in place as shipped reference content.
+
+### 11. Finalize
+
+```bash
+.gaia/cli/gaia init finalize
+```
+
+Removes the `/init` interceptor hook, prunes the matching entry from `.claude/settings.json`, and deletes the `/gaia-init` command file itself. The command will not appear in autocomplete after this point.
+
+## After init completes
+
+You should see: `<Project Title> is ready for development. Restart Claude to pick up the new plugin and skill state.`
+
+Restart Claude Code. On the next session:
+
+- The `/gaia` skill router is available with sub-routes for plan, spec, audit, handoff, pickup, forensics, and wiki maintenance.
+- `speckit.gaia.*` commands are registered.
+- The statusline shows project status and surfaces `/update-deps` and `/update-gaia` indicators when applicable.
+
+Run `pnpm dev` to verify the app boots locally.
+
+## Resuming after a failure
+
+`/gaia-init` is idempotent. If something halts mid-run, fix the cause and re-run the slash command. Already-complete CLI steps are detected via `.gaia/init-state.json` and skipped.
+
+To force a restart from a specific step:
+
+```bash
+.gaia/cli/gaia init resume --from-step <N>
+```
+
+`<N>` is 1-indexed: `1=strip-branding`, `2=configure-i18n`, `3=rename`, `4=wire-statusline`, `5=finalize`.

--- a/src/content/docs/getting-started/install.mdx
+++ b/src/content/docs/getting-started/install.mdx
@@ -1,0 +1,88 @@
+---
+title: Install
+description: Scaffold a new GAIA project with npx create-gaia.
+sidebar:
+  order: 1
+---
+
+GAIA ships as a release tarball pulled by an `npx` scaffolder. One command lays down a React Router 7 application wired for a Claude-native workflow, runs `pnpm install`, and hands the project to Claude Code for the rest of setup.
+
+## Prerequisites
+
+- Node 22.19 or later. Check with `node --version`.
+- A working terminal.
+- Claude Code installed and reachable as `claude` on your `PATH`. Optional but strongly recommended; the scaffolder auto-launches Claude into the new directory if it can find the binary.
+
+`pnpm` is not required up front. When `pnpm install` runs (the default), `create-gaia` bootstraps pnpm via Corepack if missing, falling back to `npm install -g pnpm`. With `--no-install`, no bootstrap is attempted.
+
+## Run the scaffolder
+
+```bash
+npx create-gaia@latest my-app
+```
+
+`my-app` becomes the project directory. It must be empty or not yet exist; the scaffolder refuses to write into a non-empty directory.
+
+What happens, in order:
+
+1. Resolve the latest GAIA release tag from the GitHub releases API.
+2. Download the release tarball.
+3. Extract it into `my-app/` (strip-components 1, so the tarball's top-level folder collapses into the project root).
+4. Write the version stamp to `.gaia/VERSION`.
+5. Run `git init` and create a single `chore: scaffold from GAIA <version>` commit.
+6. Run `pnpm install`.
+7. Launch Claude Code in the new directory and run `/gaia-init` automatically.
+
+If `claude` is not on your `PATH`, the scaffolder prints the manual next steps and stops cleanly. You can launch Claude yourself afterward.
+
+### Flags
+
+| Flag | Behavior |
+|---|---|
+| `--version vX.Y.Z` | Pin to a specific GAIA release. Default: latest from GitHub releases. |
+| `--no-install` | Skip `pnpm install`. |
+| `--no-git` | Skip `git init` and the initial commit. |
+| `--no-claude` | Skip auto-launching Claude Code. The scaffolder prints manual next steps instead. |
+
+### Pinning to a specific version
+
+```bash
+npx create-gaia@latest my-app --version v1.0.5
+```
+
+Useful when you want every project on a team to start from the same GAIA baseline.
+
+## What you get
+
+The scaffold ships clean. No example pages, no auth, no demo content. Just the workflow plus a working build.
+
+Top-level layout:
+
+- `app/`: application source. React Router 7, TypeScript, Tailwind v4.
+- `wiki/`: Obsidian-flavored knowledge base. Project memory that travels with the repo.
+- `.claude/`: commands, hooks, rules, skills, and agents that drive Claude Code.
+- `.gaia/`: the bundled GAIA CLI binary, statusline scripts, templates, and per-project state.
+- `.specify/`: spec-kit extension and preset that back the `/gaia spec` workflow (registered after `/gaia-init`).
+- `package.json`: pinned to `pnpm@10.33.0` via the `packageManager` field. Node `>=22.19.0` via `engines.node`.
+- Standard configs: `tsconfig.json`, `eslint.config.mjs`, `vite.config.ts`, `vitest.config.ts`, `playwright.config.ts`, `react-router.config.ts`.
+
+The `package.json` declares the bundled CLI binary at `.gaia/cli/gaia`. Slash commands in `.claude/commands/` shell out to it for deterministic operations like scaffolding components, refreshing the wiki, and stepping through init.
+
+## Next
+
+When Claude Code launches, follow the [`/gaia-init` walkthrough](/getting-started/gaia-init/).
+
+If you skipped Claude with `--no-claude`, run:
+
+```bash
+cd my-app
+claude --dangerously-skip-permissions
+```
+
+Then in Claude Code:
+
+```
+/gaia-init
+```
+
+For per-machine setup of an existing GAIA clone (a project a teammate already initialized), see [`/setup-gaia`](/getting-started/setup-gaia/).

--- a/src/content/docs/getting-started/setup-gaia.mdx
+++ b/src/content/docs/getting-started/setup-gaia.mdx
@@ -1,0 +1,112 @@
+---
+title: /setup-gaia
+description: Per-machine setup after cloning a GAIA project.
+sidebar:
+  order: 3
+---
+
+`/setup-gaia` is the per-machine pass for a cloned GAIA project. The maintainer ran `/gaia-init` once when they created the project, but the per-machine state (Claude tool installs, plugin registrations, spec-kit runtime, `.env`, the statusline executable bit) does not travel in git. Every developer who clones the repo runs this once.
+
+The slash command name does not start with `gaia-` so it stays out of the `/gaia` autocomplete namespace. Those entries are user-invoked workflows, not bootstrap.
+
+## When to use this
+
+- After `git clone`-ing a GAIA project for the first time on this machine.
+- Not after `npx create-gaia`. That triggers [`/gaia-init`](/getting-started/gaia-init/) instead.
+
+The statusline shows `Run /setup-gaia` until per-machine setup is complete. The indicator takes precedence over `/update-deps` and `/update-gaia`, which only surface after setup is finalized.
+
+You can also check on demand:
+
+```bash
+.gaia/cli/gaia setup status         # human-readable
+.gaia/cli/gaia setup status --json  # machine-readable
+```
+
+## Idempotence
+
+Each step records itself in `.gaia/local/setup-state.json`. A step is skipped if already recorded. Re-running `/setup-gaia` resumes from the first pending step, so it's safe to re-run as often as needed.
+
+## The flow
+
+### Pre-step: worktree self-heal
+
+If the clone is a linked git worktree, the shared-state symlinks (`setup-state.json`, `.gaia/cache/`, `.gaia/local/audit/`) may not exist yet. `/setup-gaia` runs:
+
+```bash
+.gaia/cli/gaia setup link-worktree
+```
+
+In a main checkout, this is a no-op. In a linked worktree without symlinks, it creates them and prints a one-line summary. Pre-existing plain files that conflict with the new symlink targets are backed up to `<path>.bak.<timestamp>` first.
+
+If symlink creation fails (typically a Windows permission issue), the run halts. Enable Windows Developer Mode and re-run.
+
+This step is not recorded in `setup-state.json`; the CLI's own idempotence handles the no-op case.
+
+### Pre-step: pnpm and node_modules
+
+If `corepack` is available, pnpm is enabled at the version pinned in `package.json`. Otherwise pnpm is installed globally via npm. If `node_modules/` is missing, `pnpm install` runs.
+
+Also not recorded in `setup-state.json`. `pnpm install` is fast on a clean clone and a no-op when the lockfile is up to date.
+
+### 1. install-tools
+
+Three external tools, identical to step 8 of [`/gaia-init`](/getting-started/gaia-init/#8-claude-tooling):
+
+- React Doctor skill
+- Playwright CLI binary
+- Serena MCP server (with `uv` bootstrapped if missing)
+
+If Serena is already registered, the installer treats the "name already exists" error as success and continues.
+
+### 2. install-plugins
+
+```bash
+claude plugin install typescript-lsp@claude-plugins-official
+claude plugin marketplace add AgriciDaniel/claude-obsidian
+claude plugin install claude-obsidian@claude-obsidian-marketplace
+```
+
+Already-installed plugins are no-ops.
+
+### 3. init-speckit
+
+Spec-kit is pinned at the floor declared in `.specify/extensions/gaia/extension.yml`. The runtime is initialized with `--here --ai claude --force`, then the GAIA extension and preset are registered.
+
+After this step, `/gaia spec` and the `speckit.gaia.*` commands light up after a Claude restart.
+
+### 4. chmod-statusline
+
+```bash
+chmod +x .gaia/statusline/*.sh
+```
+
+The executable bit is normally tracked by git but can be lost on cross-platform clones.
+
+### 5. bootstrap-env
+
+`.env` is gitignored. If `.env` is missing and `.env.example` exists, the example is copied. If neither exists, the step is a no-op (the project may not use `.env`).
+
+### 6. Optional adaptation feature
+
+You're offered an opt-in to an optional adaptation feature. The default is "Not now"; you can enable it later. If you already have a recorded preference from a previous setup pass, this step is skipped.
+
+### 7. Finalize
+
+```bash
+.gaia/cli/gaia setup finalize
+```
+
+The CLI refuses to finalize while any step is pending.
+
+After finalize, the statusline drops the `Run /setup-gaia` indicator and starts surfacing `/update-deps` and `/update-gaia` indicators when applicable. Restart Claude Code so the new plugin and skill state are picked up.
+
+## Resuming after a failure
+
+Every step is individually idempotent and recorded. After fixing any failure, re-run `/setup-gaia`. Completed steps are recorded in `.gaia/local/setup-state.json` and skipped automatically on re-run.
+
+If a maintainer initialized a clone manually before `/setup-gaia` existed, they can mark setup complete without running through the steps:
+
+```bash
+.gaia/cli/gaia setup finalize --force
+```

--- a/src/content/docs/reference/agents.mdx
+++ b/src/content/docs/reference/agents.mdx
@@ -1,0 +1,49 @@
+---
+title: Agents
+description: Reference for the subagents GAIA ships with Claude Code.
+sidebar:
+  order: 3
+---
+
+Agents are subagents Claude Code can spawn from the main conversation. Each agent runs in its own isolated context, performs a focused task, and reports back a single result. Agents are defined as Markdown files at `.claude/agents/*.md` with frontmatter that names the agent, describes when to invoke it, and pins a model.
+
+For Claude Code's own subagent documentation, see [the Subagents reference on docs.claude.com](https://docs.claude.com/en/docs/claude-code/sub-agents).
+
+## code-review-audit
+
+Path: `.claude/agents/code-review-audit.md`. Model: `sonnet`.
+
+Comprehensive code review, security audit, performance analysis, and architectural assessment. Goes beyond what ESLint and TypeScript catch by reasoning about intent, data flow, and architectural fit. **Mandatory before any PR merge.**
+
+### When to invoke
+
+- Before merging a PR. The `pr-merge-audit-check` hook blocks `gh pr merge` until the agent has produced a clean run for the current HEAD.
+- After a substantial change or refactor, when verification beyond the quality gate is warranted.
+- On request, for a focused review of the current branch.
+
+### What it reviews
+
+- **Security**: injection paths, auth/authorization gaps, secret exposure, CSRF/SSRF, data leakage through loaders, timing attacks.
+- **Performance**: N+1 patterns, unnecessary re-renders, bundle size, SSR cost in loaders, network waterfalls.
+- **Architecture**: separation of concerns, single responsibility, dependency direction, state placement, module-level duplication.
+- **Robustness**: missing validation, race conditions, null safety, error states, boundary conditions.
+- **Accessibility**: keyboard reachability, semantic HTML, focus management, ARIA usage.
+- **Maintainability**: magic values, dead code, coupling, comment quality.
+
+The main agent handles cross-cutting reasoning. Specialist subagents (React patterns, TypeScript / architecture, translation) run in parallel for line-level rule compliance, alongside `react-doctor` and `pnpm knip --reporter json`.
+
+### Output
+
+The agent produces a structured report:
+
+- **Summary**: overview, overall quality, top findings.
+- **Critical Issues (Must Fix)**: security and bugs that block merge. Each finding gives `path:line`, the issue, and a concrete fix.
+- **Important Issues (Should Fix)**: performance and architectural concerns at scale. Same shape.
+- **Suggestions (Consider Fixing)**: refactoring and minor improvements.
+- **What's Done Well**: included only when there are concrete patterns worth reinforcing.
+
+### Audit marker and trailer
+
+When the report is clean (no Critical Issues, all Important Issues resolved in the working tree), the agent stamps HEAD with a `GAIA-Audit:` commit trailer and writes a marker file at `.gaia/local/audit/<HEAD-sha>.ok`. The marker unblocks `gh pr merge` locally; the trailer travels with the commit through the network so CI can recognize an already-audited tree and skip its own audit run.
+
+If findings remain, the agent does not write the marker. Address findings, commit, and re-invoke the agent on the new HEAD.

--- a/src/content/docs/reference/hooks.mdx
+++ b/src/content/docs/reference/hooks.mdx
@@ -1,0 +1,70 @@
+---
+title: Hooks
+description: Reference for the shell hooks GAIA registers with Claude Code.
+sidebar:
+  order: 1
+---
+
+Hooks are shell scripts Claude Code runs in response to events: when a session starts, when a prompt is submitted, before or after a tool call, and so on. Most of GAIA's hooks live at `.claude/hooks/*.sh` and are registered in `.claude/settings.json` under the `hooks` key, keyed by event name. A few helper scripts under `.gaia/scripts/` are registered the same way for events outside the standard tool-call surface.
+
+Most hooks here either block dangerous tool calls outright (deny the call with a reason shown to Claude) or inject a one-line nudge into context. A few are advisory: they run, log a reminder to stderr, and exit clean.
+
+For Claude Code's own hook documentation, see [the Hooks reference on docs.claude.com](https://docs.claude.com/en/docs/claude-code/hooks).
+
+## SessionStart
+
+| Hook | What it does | Path |
+|---|---|---|
+| `wiki-session-start` | Records HEAD into `.git/claude-session-start` so the Stop hook can detect wiki commits during the session, and re-asserts per-machine memory contracts. | `.claude/hooks/wiki-session-start.sh` |
+
+## Stop
+
+| Hook | What it does | Path |
+|---|---|---|
+| `wiki-session-stop` | If wiki files were committed during the session, prompts a hot-cache refresh; nags `/gaia wiki sync` when commits land but `wiki/.state.json` did not advance. | `.claude/hooks/wiki-session-stop.sh` |
+| `wiki-squash-autocommits` | Squashes the trailing run of `wiki: auto-commit` commits into one; on `main`, redirects the squash to a `wiki/*` branch and merges via PR. | `.claude/hooks/wiki-squash-autocommits.sh` |
+
+## UserPromptSubmit
+
+| Hook | What it does | Path |
+|---|---|---|
+| `wiki-drift-check` | Detects drift between `wiki/.state.json` and HEAD; injects a once-per-session reminder when drifted. | `.claude/hooks/wiki-drift-check.sh` |
+
+## UserPromptExpansion
+
+| Hook | Matcher | What it does | Path |
+|---|---|---|---|
+| `intercept-init` | `init` | Redirects `/init` to `/gaia-init` so the built-in flow does not overwrite GAIA's curated `CLAUDE.md`. | `.claude/hooks/intercept-init.sh` |
+
+## PreToolUse (Edit / Write / MultiEdit)
+
+| Hook | What it does | Path |
+|---|---|---|
+| `block-env-write` | Denies writes to `.env` and `.env.*` files; allows `.env.example`. | `.claude/hooks/block-env-write.sh` |
+| `block-eslint-config-edit` | Denies edits to `eslint.config.{js,cjs,mjs,ts}`; force fixes back into the source file where the lint error occurred. | `.claude/hooks/block-eslint-config-edit.sh` |
+| `block-lockfile-edit` | Denies direct edits to `pnpm-lock.yaml`; lockfile changes must come from `pnpm install`. | `.claude/hooks/block-lockfile-edit.sh` |
+| `block-secrets-write` | Denies writes that contain AWS keys, GitHub PATs, private-key headers, or non-placeholder `_TOKEN`/`_SECRET`/`_KEY`/`_PASSWORD` assignments. | `.claude/hooks/block-secrets-write.sh` |
+| `block-vitest-globals-tsconfig` | Blocks adding `vitest/globals` to `tsconfig.json`; tests must use explicit imports from `vitest`. | `.claude/hooks/block-vitest-globals-tsconfig.sh` |
+| `check-i18n-strings` | Advisory once-per-session reminder when a `.tsx` file under `app/pages/` or `app/components/` is edited; does not block. | `.claude/hooks/check-i18n-strings.sh` |
+| `check-story-exists` | Advisory reminder to add a Storybook story when a new component `index.tsx` is written without a sibling `tests/index.stories.tsx`. | `.claude/hooks/check-story-exists.sh` |
+
+## PreToolUse (Bash)
+
+| Hook | What it does | Path |
+|---|---|---|
+| `block-bare-test` | Blocks bare `pnpm test` / `npm test` invocations; requires `--run` so vitest does not start watch mode. | `.claude/hooks/block-bare-test.sh` |
+| `block-main-destructive-git` | Blocks commits to `main`/`master` and force-pushes to those branches. | `.claude/hooks/block-main-destructive-git.sh` |
+| `block-rm-rf` | Denies `rm -rf` against root, `$HOME`, cwd, unscoped globs, `.git`, `node_modules`, and any path outside a small whitelist of scratch dirs. | `.claude/hooks/block-rm-rf.sh` |
+| `pr-merge-audit-check` | Blocks `gh pr merge` until a code-review-audit marker file exists at `.gaia/local/audit/<HEAD-sha>.ok`. | `.claude/hooks/pr-merge-audit-check.sh` |
+
+## PostToolUse (Bash)
+
+| Hook | What it does | Path |
+|---|---|---|
+| `wiki-commit-nudge` | After every non-amend `git commit`, injects commit metadata and the current wiki drift count into context. | `.claude/hooks/wiki-commit-nudge.sh` |
+
+## Agent-invoked (no event registration)
+
+| Hook | What it does | Path |
+|---|---|---|
+| `audit-stamp-trailer` | Writes the `GAIA-Audit:` commit trailer on HEAD so CI can recognize an already-audited tree. Called by the `code-review-audit` agent at the end of a clean review. | `.claude/hooks/audit-stamp-trailer.sh` |

--- a/src/content/docs/reference/rules.mdx
+++ b/src/content/docs/reference/rules.mdx
@@ -1,0 +1,35 @@
+---
+title: Rules
+description: Reference for the path-scoped rule files GAIA loads into Claude's context.
+sidebar:
+  order: 2
+---
+
+Rules live at `.claude/rules/*.md`. Each rule is a short Markdown file that Claude loads into context when the work touches a matching path. The `instruction-files` rule itself enforces the convention: paths inside template-distributed files must be repo-relative, never absolute, so they resolve correctly on every machine.
+
+A rule's frontmatter `paths:` field is the gate. When Claude edits or reads a file matching one of those globs, the rule body is included automatically. Rules without a `paths:` field are always loaded.
+
+## Always loaded
+
+| Rule | What it enforces |
+|---|---|
+| `coding-guidelines` | File-naming conventions (PascalCase components, camelCase hooks, kebab-case other), simplicity-first, surgical changes, goal-driven execution, mandatory TDD, mandatory quality-gate run before commit. |
+| `knip` | When and when not to run `pnpm knip`; the audit agent runs it pre-merge, manual runs only after a refactor, deletion, or dependency replacement. |
+| `quality-gate` | Run the steps in `wiki/decisions/Quality Gate.md` before any commit that touches source, unless nothing in the gate's scope is staged. |
+| `shell-cwd` | No `cd` in Bash tool calls; use absolute paths. A persistent `cd` breaks the relative-path hooks registered in `settings.json`. |
+
+## Path-scoped
+
+| Rule | What it enforces | Paths |
+|---|---|---|
+| `accessibility` | Keyboard reachability, alt text, focus management on modals, semantic HTML over ARIA roles, color never the sole indicator. | `app/components/**`, `app/pages/**` |
+| `api-service` | Pointer to the API Service Pattern wiki page and the `new-service` skill; no inline rules. | `app/services/**`, `test/mocks/**` |
+| `code-search` | Prefer Serena's MCP tools for symbol-level queries on TS/TSX; fall back to Read+grep for prose, comments, and files outside `app/**`/`test/**`. | `app/**/*.ts`, `app/**/*.tsx`, `test/**/*.ts`, `test/**/*.tsx` |
+| `i18n` | Every user-facing string comes from `t()`; one `useTranslation()` per component; namespace conventions and key file layout under `app/languages/en/`. | `app/pages/**`, `app/components/**`, `app/languages/**` |
+| `instruction-files` | All paths in template-distributed files under `.claude/` must be repo-relative; provides an audit grep for absolute-path leaks. | `.claude/**` |
+| `playwright` | E2E spec layout, semantic selectors over CSS, web-first assertions only, hydration helper before interaction, MSW behavior in dev, parallelism and CI settings. | `.playwright/**`, `playwright.config.*` |
+| `routes` | Pointer to thin-route conventions in the wiki and the `new-route` skill; route files stay loader/action-only. | `app/routes/**`, `app/pages/**` |
+| `state-pattern` | Context creation lives in `app/state/`; naming conventions for Provider/`useX`/`useMaybeX`; never export the Context; provider composition via `app/state/index.tsx`. | `app/state/**` |
+| `storybook` | Story file location and typing, slash-separated titles, decorator order, fullscreen layout with `wrap: 'p-4'` for padding, variant-name table, Chromatic dark-mode handling. | `app/**/*.stories.tsx`, `.storybook/**` |
+| `tailwind` | Tailwind v4 only (config in `app/styles/tailwind.css`, no `tailwind.config.ts`); semantic `@utility` tokens over raw paired classes; no arbitrary hex colors in `[]`. | `app/**/*.tsx`, `app/**/*.css` |
+| `wiki-style` | Present-tense prose; no UAT/SPEC/PR/commit references in body prose; no historical phrasing; ships an audit grep for violations. | `wiki/**/*.md`, `app/**/*.{ts,tsx,js,jsx,css}`, `.claude/{skills,commands,agents,rules}/**/*.md`, `.claude/hooks/**/*.sh`, `.specify/extensions/gaia/{README.md,commands,lib,rules,templates}/**` |

--- a/src/content/docs/skills/code.mdx
+++ b/src/content/docs/skills/code.mdx
@@ -1,0 +1,86 @@
+---
+title: Code skills
+description: Skills that govern how Claude writes and edits TypeScript, React, Tailwind, tests, and browser automation in your project.
+sidebar:
+  order: 1
+---
+
+Seven skills that govern code generation and review. Each one loads automatically when its trigger phrasing matches the conversation. You don't invoke them by name.
+
+## Language
+
+### `typescript`
+
+Patterns and conventions for TypeScript across the project: camelCase identifiers, `type` over `interface`, explicit return types on exported functions, no enums, no `switch`, max three positional parameters, Zod's `z.literal()` over `z.enum()`, and naming guidance modeled on Apple's Swift API Design Guidelines.
+
+**Triggers** when writing or reviewing TypeScript: typing exports, choosing between `type` and `interface`, defining Zod schemas, structuring function parameters, naming identifiers, or enforcing patterns like avoiding switch statements and enums.
+
+**Example phrasing:** "type this Zod schema", "should this be a type or an interface", "name this hook better".
+
+Source: `.claude/skills/typescript/SKILL.md`.
+
+### `react-code`
+
+Conventions for React components, pages, routes, hooks, and forms. Includes pre-flight gates for `useEffect`, `useCallback`, and `useState`; a form-element check that swaps native `<input>` for the project's `Form/*` components; and a translation gate that requires every user-visible string to come from `t()`. Covers component extraction thresholds and route/page architecture (`app/routes/` thin shells, `app/pages/` for UI).
+
+**Triggers** when writing or reviewing React components, hooks (`useEffect`, `useCallback`, `useState`), event handlers, or component extraction decisions. Also triggers when debugging stale closures, infinite re-renders, or unnecessary re-renders caused by memoization issues.
+
+**Example phrasing:** "this useEffect is firing twice", "extract this section into its own component", "wire up a Conform form for sign-up".
+
+Source: `.claude/skills/react-code/SKILL.md`.
+
+## Styling
+
+### `tailwind`
+
+Tailwind conventions: built-in scale first, `rem` for custom values (never `px`), `twJoin` for conditional classes, `twMerge` for caller-overridable defaults, `Record<Variant, string>` lookup tables for multi-class variants, role-based `@theme` token names that survive being prefixed with every utility (`bg-`, `text-`, `border-`, `ring-`, etc.).
+
+**Triggers** when writing Tailwind class names, combining conditional classes, building component variants, choosing between `twJoin` and `twMerge`, defining `@theme` tokens, picking between `rem` and `px`, or working with responsive breakpoints.
+
+**Example phrasing:** "this needs a hover variant", "name this color token", "should I use twJoin or twMerge here".
+
+Source: `.claude/skills/tailwind/SKILL.md`.
+
+### `skeleton-loaders`
+
+Build skeleton loading states that are pixel-perfect matches of the real content. Uses real HTML elements (`<p>`, `<span>`, `<h2>`, `<button>`) with the same font classes plus a shared `shimmer` class for the gradient animation; non-text elements stay as empty `<div>`s. Includes the 200ms delay pattern that suppresses skeleton flash on fast loads.
+
+**Triggers** when adding loading states, building skeletons for async data, handling pending loader states in route transitions, implementing the shimmer animation pattern, or preventing layout shift during data fetching.
+
+**Example phrasing:** "add a skeleton for this profile card", "the layout jumps when data loads", "this skeleton flashes on fast loads".
+
+Source: `.claude/skills/skeleton-loaders/SKILL.md`.
+
+## Testing
+
+### `tdd`
+
+Test-driven development with a vertical-slice red-green-refactor loop. Treats horizontal slicing (write all tests first, then all code) as an anti-pattern. Tests verify behavior through public interfaces, not implementation details. Includes a per-cycle checklist and a planning step that asks for the public interface before writing the first red test.
+
+**Triggers** when building features or fixing bugs with TDD, mentioning "red-green-refactor", asking for integration tests, or asking for test-first development.
+
+**Example phrasing:** "let's TDD this", "write a red test for the login flow", "I want a tracer bullet for the new endpoint".
+
+Source: `.claude/skills/tdd/SKILL.md`.
+
+### `playwright-cli`
+
+Browser automation via the `playwright-cli` binary: navigate, click, type, screenshot, manage cookies and storage, run multiple parallel sessions, and read element refs from auto-generated snapshot files (`.playwright-cli/page-*.yml`). Falls back to `npx playwright-cli` when the global binary is not on `PATH`.
+
+**Triggers** when navigating websites, interacting with web pages, filling forms, taking screenshots, testing web applications, or extracting information from web pages.
+
+**Example phrasing:** "screenshot the staging site at /pricing", "fill out the signup form on localhost:5173", "extract the headline text from this URL".
+
+Source: `.claude/skills/playwright-cli/SKILL.md`.
+
+## Cleanup
+
+### `eslint-fixes`
+
+Project-specific recipes for the ESLint rules that flare on this stack: `no-void` (use `async`/`await` instead), `canonical/export-specifier-newline` versus prettier (use inline `export const`), `no-shadow` trailing underscores, `sonarjs/deprecation` (fix the deprecation; don't suppress), `you-dont-need-lodash-underscore` (use native methods), `testing-library/prefer-screen-queries`, `testing-library/await-async-events`, `jest-dom/prefer-*`.
+
+**Triggers** when fixing lint failures, ESLint reported issues, or autofix conflicts.
+
+**Example phrasing:** "fix this no-void error", "ESLint is fighting prettier on this export", "convert these jest-dom assertions".
+
+Source: `.claude/skills/eslint-fixes/SKILL.md`.

--- a/src/content/docs/skills/index.mdx
+++ b/src/content/docs/skills/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Skills
+description: GAIA's skill catalog. Code patterns, scaffolders, and maintenance routines that load when you ask for them.
+sidebar:
+  order: 0
+---
+
+A skill is a self-contained bundle of patterns, conventions, and workflows that Claude loads when the conversation matches its trigger phrasing. Skills live as `SKILL.md` files with a frontmatter description; the description tells Claude *when* to load the skill.
+
+GAIA ships its skills under `.claude/skills/` in your project. Each one is a directory with a `SKILL.md` and (sometimes) supporting `references/` files that load on demand.
+
+## Catalog
+
+GAIA groups its skills into three categories:
+
+**Code skills** govern how code is written and reviewed. Trigger when you write or edit TypeScript, React, Tailwind, tests, or browser automation. See [Code skills](/skills/code/).
+
+**Scaffolders** generate new files from templates. Trigger when you ask to create a component, hook, route, or service. See [Scaffolders](/skills/scaffolders/).
+
+**Maintenance** handles upkeep on the project itself. Trigger when you bump dependencies or pull a new GAIA release. See [Maintenance](/skills/maintenance/).
+
+There's one more skill, `gaia`, that acts as a router. It exposes sub-routes like `/gaia plan`, `/gaia spec`, and `/gaia audit`. See [The /gaia router](/gaia/).
+
+## How triggering works
+
+Each `SKILL.md` has a `description:` field that lists the phrasings and situations that load the skill. The skills do not run on every prompt; they activate when the description matches what you said. You don't invoke them by name. Saying "scaffold a card called PriceCard" loads `new-component`. Saying "the typecheck is angry about a stale closure" loads `react-code`.
+
+A few skills are also wired to the statusline. When `update-deps` or `update-gaia` detect pending work, the statusline shows a `Run /update-deps` or `Run /update-gaia` indicator; clicking the indicator loads the skill.
+
+## Adding your own
+
+Skills are plain markdown. Drop a new directory under `.claude/skills/<name>/` with a `SKILL.md` whose frontmatter sets `name`, `description`, and (optionally) `model:` to pin a model tier. Claude picks it up on the next session.

--- a/src/content/docs/skills/maintenance.mdx
+++ b/src/content/docs/skills/maintenance.mdx
@@ -1,0 +1,68 @@
+---
+title: Maintenance
+description: Skills that keep the project current. Bump dependencies and pull new GAIA releases without clobbering your customizations.
+sidebar:
+  order: 3
+---
+
+Two skills that handle upkeep on the project itself. Both are wired to the statusline. When work is pending, the statusline shows a `Run /update-deps` or `Run /update-gaia` indicator; clicking the indicator loads the skill. You can also trigger them by phrasing.
+
+## `update-deps`
+
+Autonomous Dependabot. Discovers outdated packages with `pnpm outdated --json`, audits `pnpm.overrides` for entries that are no longer needed, applies migrations for major version bumps, resolves dependency conflicts, and runs the full quality gate (`pnpm typecheck`, `pnpm lint`, `pnpm test --run`, `pnpm pw`, `pnpm build`).
+
+**How it picks targets**
+
+Updates are grouped so companion packages move together. For example, when any of `react-router`, `@react-router/dev`, or `@react-router/serve` is outdated, the whole `react-router` group ships in the same install. Other groups include `react`, `tailwindcss`, `storybook`, `vitest`, `playwright`, `eslint`, `testing-library`, `typescript`, `i18next`, `msw`, `vite`, `zod-conform`, `fontawesome`, `stylelint`, `prettier`, `husky`. Packages outside any group form singleton groups.
+
+After grouping, updates are classified into waves: Wave A bundles minor and patch bumps into one install, Wave B processes each major-bump group individually with its own migration guide and code edits.
+
+**Pinned versions** in `package.json` (no `^` or `~`) stay pinned to the exact target. Unpinned specs use `^<latest>`.
+
+**ESLint cap.** ESLint and `@eslint/js` are capped at the highest available `9.x`. If a `10.x` major is published, the skill still targets `9.x.y` silently. Capped packages do not appear in the report.
+
+**Triggers** when you click the statusline `Run /update-deps` indicator, or ask "update dependencies", "bump deps", "run dependabot".
+
+**Gotchas**
+
+- Must run from the main checkout, not a linked worktree. The skill rejects worktree invocations early and surfaces the cached outdated count from main so you know whether action is even pending.
+- Must run from `main` or `master`, or from an existing chore branch. If on `main`, the skill creates `chore/update-deps-<timestamp>`.
+- The final report is built from agent-returned data only. Anything filtered before installation (the ESLint cap) is silent on purpose.
+
+Source: `.claude/skills/update-deps/SKILL.md`.
+
+## `update-gaia`
+
+Pulls the latest GAIA release into your project without overwriting your customizations. Does a three-way comparison (your file / baseline tarball / latest tarball) per file, using ownership classes from `.gaia/manifest.json`:
+
+- **`owned`**: GAIA controls fully. Overwritten silently when unchanged from baseline; prompts on drift.
+- **`shared`**: GAIA seeds, you customize. On drift, emits a `.gaia-merge/<path>.patch` for manual resolution.
+- **`wiki-owned`**: GAIA-seeded wiki pages (concepts, decisions, modules). Same drift handling as `shared`.
+- **adopter-owned** (implicit): anything not in the manifest, plus sentinels like `wiki/hot.md`, `wiki/log.md`, `CHANGELOG.md`, `.gaia/VERSION`, `.gaia/manifest.json`. Never touched.
+
+**What it does**
+
+1. Reads `.gaia/VERSION` to determine the baseline.
+2. Resolves the latest release tag via `gh release list --repo gaia-react/gaia` (falls back to the GitHub API).
+3. Shows the release notes and asks you to confirm.
+4. Downloads the baseline and latest tarballs into `.gaia/cache/` (gitignored).
+5. Runs `gaia update merge` to compute the three-way diff per file.
+6. Walks any conflicts with you one at a time; reads `.gaia-merge/<path>.patch` for each.
+7. Prompts before deleting any file that the latest release removed.
+8. Writes the new version to `.gaia/VERSION` and copies the latest manifest into `.gaia/manifest.json`.
+9. Prints a summary with counts (overwritten, added, skipped, conflicts, deleted, backed up).
+
+Backups land in `.gaia-backup/<timestamp>/`. Conflict patches land in `.gaia-merge/`.
+
+**Triggers** when you click the statusline `Run /update-gaia` indicator, or ask "update GAIA", "pull the latest GAIA", "apply the new GAIA release".
+
+**Gotchas**
+
+- Must run from the main checkout, not a linked worktree. The skill rejects worktree invocations early.
+- Must run from `main` or `master`, or from an existing chore branch. If on `main`, the skill creates `chore/update-gaia-<timestamp>`.
+- Refuses to downgrade. If `.gaia/VERSION` is ahead of the latest release, the skill warns and exits.
+- Requires a baseline tarball. If your installed version predates the manifest mechanism, the skill stops and tells you to cherry-pick manually.
+- Does not auto-commit. Review the diff yourself, then commit with `chore: update GAIA to <tag>`.
+- After completion, review patches in `.gaia-merge/`, run the quality gate, and inspect `git diff` before committing.
+
+Source: `.claude/skills/update-gaia/SKILL.md`.

--- a/src/content/docs/skills/scaffolders.mdx
+++ b/src/content/docs/skills/scaffolders.mdx
@@ -1,0 +1,70 @@
+---
+title: Scaffolders
+description: Skills that scaffold new components, hooks, routes, and services from project templates.
+sidebar:
+  order: 2
+---
+
+Four skills that generate new files following the project's conventions. Each one confirms a few details, runs a `gaia scaffold` command, and verifies the output with `pnpm typecheck`.
+
+The skills are the user-facing surface. They wrap the bundled `gaia scaffold` CLI so you don't memorize flags. Run them by describing what you want; the skill prompts for anything missing.
+
+## `new-component`
+
+Scaffolds a React component as a folder under `app/components/` (or a sub-folder you specify) with `index.tsx`, an optional Storybook story, and a Vitest test scaffold.
+
+**Confirms:** name (PascalCase), parent directory (default `app/components`), props (or "none"), include a story (default yes).
+
+**Triggers** when you ask to create a component, scaffold a card, make a button, or add a new component.
+
+**Example phrasing:** "create a PriceCard component", "scaffold a button under app/components/Form", "make a new component called UserAvatar with a name and url prop".
+
+Underlying CLI: `gaia scaffold component <Name> [--no-story] [--parent <dir>] [--props "a:string,b:number"]`.
+
+Source: `.claude/skills/new-component/SKILL.md`.
+
+## `new-hook`
+
+Scaffolds a custom React hook with a Vitest test file.
+
+**Confirms:** name (must start with `use`), params, return type.
+
+**Triggers** when you ask to create a hook, make a `useFoo` hook, scaffold a custom React hook, or add a hook under `app/hooks`. Also triggers when describing reusable React state or effect logic that warrants extraction into a named `use*` hook.
+
+**Example phrasing:** "make a useCountdown hook", "scaffold useDebouncedValue with a value and delay parameter", "extract this into a useFormSubmission hook".
+
+Underlying CLI: `gaia scaffold hook <useFoo> [--params "a:string,b:number"] [--returns "ReturnType"]`.
+
+Source: `.claude/skills/new-hook/SKILL.md`.
+
+## `new-route`
+
+Scaffolds a new route with its page component, test, story, and optional i18n keys. Files land in `app/routes/<group>+/<name>.tsx` plus `app/pages/<Group>/<PageName>/index.tsx`. The route file stays a thin shell (`loader`, `action`, `meta`, Zod schemas, one-line default export); UI lives in the page component.
+
+**Confirms:** name (kebab-case), group (`_public+` or `_session+`), and which of `--loader`, `--action`, `--i18n` to include.
+
+**Triggers** when you ask to create a route, add a new page, scaffold a path like `/dashboard`, or wire up a new route under `_public+` or `_session+`.
+
+**Example phrasing:** "add a /pricing page in _public+", "scaffold /settings/profile under _session+ with a loader and action", "create a new route /forgot-password with i18n".
+
+Underlying CLI: `gaia scaffold route <name> --group <_public+|_session+> [--loader] [--action] [--i18n] [--json]`.
+
+Source: `.claude/skills/new-route/SKILL.md`.
+
+## `new-service`
+
+Scaffolds an API service: request functions, Zod parsers, URL constants, types, and (optionally) MSW mock handlers. Files land under `app/services/gaia/<name>/` with matching mocks under `test/mocks/<name>/`.
+
+**Confirms:** name (kebab-case), endpoints (subset of `get`, `post`, `put`, `delete`), schema as `name:type` pairs, include MSW mocks.
+
+**Triggers** when you ask to add a service, create the API for a resource, scaffold a new GAIA service, or wire up CRUD for a resource.
+
+**Example phrasing:** "add a projects service with get and post", "scaffold a users API with id, email, and a status enum", "wire up CRUD for tasks with mocks".
+
+Underlying CLI: `gaia scaffold service <name> --endpoints "get,post,put,delete" --schema "id:string,name:string,status:enum(active,archived)" [--mocks] [--json]`.
+
+Schema types: `string`, `number`, `boolean`, `datetime`, `enum(a,b,...)`. Append `?` to mark a field optional.
+
+The skill stops short of wiring the service into a consuming page or hook. That step stays manual so you can decide where the service belongs.
+
+Source: `.claude/skills/new-service/SKILL.md`.


### PR DESCRIPTION
## Summary
- 25 new content pages across Getting started, Commands, /gaia, Skills, Reference, Contributors
- Sidebar registered; build passes at 26 pages
- Adopter/contributor split enforced; do-not-document.yml respected for both audiences (mentorship, telemetry, release subcommands, _internal-* CLI surface)

## Scope

**Adopter pages (19):** install, /gaia-init walkthrough, /setup-gaia walkthrough, commands overview, /gaia router + 6 sub-routes (plan, spec, audit, handoff/pickup, forensics, wiki), skills overview + 3 grouped pages, reference (hooks, rules, agents).

**Contributor pages (6):** index, release, health-audit, CLI surface, CI workflows, wiki internals.

**Spec-kit lifecycle hooks** are folded into `/gaia/spec/` as a 5-row table. Users never invoke spec-kit primitives directly.

## Verification
- 7 docs-audit subagents ran in parallel, must-fix items applied
- Voice-check clean (no em dashes outside literal system-output backticks, no AI tells, no banned jargon)
- Build verified at 26 pages

## Test plan
- [ ] Visit https://docs.gaiareact.com after deploy and spot-check the sidebar groupings
- [ ] Click through /getting-started/install, /gaia/plan, /gaia/spec to verify cross-links resolve
- [ ] Confirm /contributors/ pages render and that no /spec-kit/ link is dangling

🤖 Generated with [Claude Code](https://claude.com/claude-code)